### PR TITLE
Fix default timestamp value

### DIFF
--- a/lib/Services/DatabaseMigration.php
+++ b/lib/Services/DatabaseMigration.php
@@ -92,8 +92,8 @@ class DatabaseMigration
         CREATE TABLE ${userTablename} (
             id VARCHAR(255) PRIMARY KEY NOT NULL,
             claims TEXT,
-            updated_at TIMESTAMP NOT NULL DEFAULT '1970-01-01 00:00:01',
-            created_at TIMESTAMP NOT NULL DEFAULT '1970-01-01 00:00:01'
+            updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+            created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
         )
 EOT
         );
@@ -117,7 +117,7 @@ EOT
         CREATE TABLE ${accessTokenTableName} (
             id VARCHAR(255) PRIMARY KEY NOT NULL,
             scopes TEXT,
-            expires_at TIMESTAMP NOT NULL DEFAULT '1970-01-01 00:00:01',
+            expires_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
             user_id VARCHAR(255) NOT NULL,                          
             client_id VARCHAR(255) NOT NULL,
             is_revoked BOOLEAN NOT NULL DEFAULT false,
@@ -131,7 +131,7 @@ EOT
         $this->database->write(<<< EOT
         CREATE TABLE ${refreshTokenTableName} (
             id VARCHAR(255) PRIMARY KEY NOT NULL,          
-            expires_at TIMESTAMP NOT NULL DEFAULT '1970-01-01 00:00:01',
+            expires_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
             access_token_id VARCHAR(255) NOT NULL,
             is_revoked BOOLEAN NOT NULL DEFAULT false,
             CONSTRAINT fk_refresh_token_access_token FOREIGN KEY (access_token_id) REFERENCES ${accessTokenTableName} (id) ON DELETE CASCADE
@@ -144,7 +144,7 @@ EOT
         CREATE TABLE ${authCodeTableName} (
             id VARCHAR(255) PRIMARY KEY NOT NULL,
             scopes TEXT,
-            expires_at TIMESTAMP NOT NULL DEFAULT '1970-01-01 00:00:01',
+            expires_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
             user_id VARCHAR(255) NOT NULL,                          
             client_id VARCHAR(255) NOT NULL,
             is_revoked BOOLEAN NOT NULL DEFAULT false,


### PR DESCRIPTION
CURRENT_TIMESTAMP is compatible with mysql, mariadb, postgresql
and sqlite3.