### PR TITLE
Fixed must validate secret issue

### DIFF
--- a/lib/Repositories/ClientRepository.php
+++ b/lib/Repositories/ClientRepository.php
@@ -38,10 +38,6 @@ class ClientRepository extends AbstractDatabaseRepository implements ClientRepos
             return null;
         }
 
-        if ($mustValidateSecret && $clientSecret !== $client->getSecret()) {
-            return null;
-        }
-
         return $client;
     }
 

--- a/tests/Repositories/ClientRepositoryTest.php
+++ b/tests/Repositories/ClientRepositoryTest.php
@@ -84,15 +84,6 @@ class ClientRepositoryTest extends TestCase
         $this->assertNotNull($client);
     }
 
-    public function testGetClientEntityWithWrongSecretAndNotFound()
-    {
-        $client = self::getClient('clientid');
-        self::$repository->add($client);
-
-        $client = self::$repository->getClientEntity('clientid', null, 'wrongsecret', true);
-        $this->assertNull($client);
-    }
-
     public function testGetDisabledClientEntity()
     {
         $client = self::getClient('clientid', false);


### PR DESCRIPTION
OAuth2 server implementantion is requesting to validate the client
secret always. But it is not required for implicit and explicit
grants.

This validation is removed from our clientRepository interface
implementation because we only supports implicit and explicit
grants.