### PR TITLE
Fixed saved token in session

### DIFF
--- a/lib/Form/ClientForm.php
+++ b/lib/Form/ClientForm.php
@@ -35,7 +35,7 @@ class ClientForm extends Form
         $this->onValidate[] = [$this, 'validateRedirectUri'];
 
         $this->setMethod('POST');
-        $this->addProtection('Security token has expired, please submit the form again');
+        $this->addComponent(new Controls\CsrfProtection(null), Form::PROTECTOR_ID);
 
         $this->addText('name', '{oidc:client:name}')
             ->setMaxLength(255)

--- a/lib/Form/Controls/CsrfProtection.php
+++ b/lib/Form/Controls/CsrfProtection.php
@@ -1,0 +1,41 @@
+<?php
+
+/*
+ * This file is part of the simplesamlphp-module-oidc.
+ *
+ * Copyright (C) 2018 by the Spanish Research and Academic Network.
+ *
+ * This code was developed by Universidad de Córdoba (UCO https://www.uco.es)
+ * for the RedIRIS SIR service (SIR: http://www.rediris.es/sir)
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace SimpleSAML\Modules\OpenIDConnect\Form\Controls;
+
+use Nette\Forms\Controls\CsrfProtection as BaseCsrfProtection;
+use SimpleSAML\Utils\Random;
+
+class CsrfProtection extends BaseCsrfProtection
+{
+    public function __construct($errorMessage)
+    {
+        parent::__construct($errorMessage);
+
+        $this->session = \SimpleSAML_Session::getSession();
+    }
+
+    public function getToken()
+    {
+        $token = $this->session->getData('token', 'form');
+
+        if (!isset($token)) {
+            $token = Random::generateID();
+
+            $this->session->setData('token', 'form', $token);
+        }
+
+        return $token;
+    }
+}


### PR DESCRIPTION
The component `Nette/Controls/CsrfProtection` uses is own `Session`
class than conflicts with SimpleSaml Session.

Created a new CsrfProtection control than uses SSP session.

Closes #12 