### PR TITLE
Changed IdTokenResponse class

### DIFF
--- a/lib/Factories/IdTokenResponseFactory.php
+++ b/lib/Factories/IdTokenResponseFactory.php
@@ -1,0 +1,58 @@
+<?php
+
+/*
+ * This file is part of the simplesamlphp-module-oidc.
+ *
+ * Copyright (C) 2018 by the Spanish Research and Academic Network.
+ *
+ * This code was developed by Universidad de Córdoba (UCO https://www.uco.es)
+ * for the RedIRIS SIR service (SIR: http://www.rediris.es/sir)
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace SimpleSAML\Modules\OpenIDConnect\Factories;
+
+use Lcobucci\JWT\Builder;
+use SimpleSAML\Modules\OpenIDConnect\ClaimTranslatorExtractor;
+use SimpleSAML\Modules\OpenIDConnect\Repositories\UserRepository;
+use SimpleSAML\Modules\OpenIDConnect\Server\ResponseTypes\IdTokenResponse;
+use SimpleSAML\Modules\OpenIDConnect\Services\ConfigurationService;
+
+class IdTokenResponseFactory
+{
+    /**
+     * @var UserRepository
+     */
+    private $userRepository;
+
+    /**
+     * @var ConfigurationService
+     */
+    private $configurationService;
+
+    public function __construct(
+        UserRepository $userRepository,
+        ConfigurationService $configurationService
+    ) {
+        $this->userRepository = $userRepository;
+        $this->configurationService = $configurationService;
+    }
+
+    public function build()
+    {
+        $builder = (new Builder())
+            ->setIssuer($this->configurationService->getSimpleSAMLSelfURLHost())
+            ->setHeader('kid', 'oidc')
+        ;
+
+        $token = new IdTokenResponse(
+            $this->userRepository,
+            new ClaimTranslatorExtractor(),
+            $builder
+        );
+
+        return $token;
+    }
+}

--- a/lib/Server/ResponseTypes/IdTokenResponse.php
+++ b/lib/Server/ResponseTypes/IdTokenResponse.php
@@ -1,0 +1,125 @@
+<?php
+
+/*
+ * This file is part of the simplesamlphp-module-oidc.
+ *
+ * Copyright (C) 2018 by the Spanish Research and Academic Network.
+ *
+ * This code was developed by Universidad de Córdoba (UCO https://www.uco.es)
+ * for the RedIRIS SIR service (SIR: http://www.rediris.es/sir)
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace SimpleSAML\Modules\OpenIDConnect\Server\ResponseTypes;
+
+use Lcobucci\JWT\Builder;
+use Lcobucci\JWT\Signer\Key;
+use Lcobucci\JWT\Signer\Rsa\Sha256;
+use League\OAuth2\Server\Entities\AccessTokenEntityInterface;
+use League\OAuth2\Server\Entities\ScopeEntityInterface;
+use League\OAuth2\Server\Entities\UserEntityInterface;
+use League\OAuth2\Server\ResponseTypes\BearerTokenResponse;
+use OpenIDConnectServer\ClaimExtractor;
+use OpenIDConnectServer\Entities\ClaimSetInterface;
+use OpenIDConnectServer\Repositories\IdentityProviderInterface;
+
+/**
+ * Class IdTokenResponse.
+ *
+ * @author Steve Rhoades <sedonami@gmail.com>
+ * @license http://opensource.org/licenses/MIT MIT
+ *
+ * @see https://github.com/steverhoades/oauth2-openid-connect-server/blob/master/src/IdTokenResponse.php
+ */
+class IdTokenResponse extends BearerTokenResponse
+{
+    /**
+     * @var IdentityProviderInterface
+     */
+    protected $identityProvider;
+
+    /**
+     * @var ClaimExtractor
+     */
+    protected $claimExtractor;
+    /**
+     * @var Builder
+     */
+    private $builder;
+
+    public function __construct(
+        IdentityProviderInterface $identityProvider,
+        ClaimExtractor $claimExtractor,
+        Builder $builder
+    ) {
+        $this->identityProvider = $identityProvider;
+        $this->claimExtractor = $claimExtractor;
+        $this->builder = $builder;
+    }
+
+    /**
+     * @param AccessTokenEntityInterface $accessToken
+     *
+     * @return array
+     */
+    protected function getExtraParams(AccessTokenEntityInterface $accessToken)
+    {
+        if (false === $this->isOpenIDRequest($accessToken->getScopes())) {
+            return [];
+        }
+
+        /** @var UserEntityInterface $userEntity */
+        $userEntity = $this->identityProvider->getUserEntityByIdentifier($accessToken->getUserIdentifier());
+
+        if (false === is_a($userEntity, UserEntityInterface::class)) {
+            throw new \RuntimeException('UserEntity must implement UserEntityInterface');
+        } elseif (false === is_a($userEntity, ClaimSetInterface::class)) {
+            throw new \RuntimeException('UserEntity must implement ClaimSetInterface');
+        }
+
+        // Add required id_token claims
+        $builder = $this->builder
+            ->setAudience($accessToken->getClient()->getIdentifier())
+            ->setIssuedAt(time())
+            ->setExpiration($accessToken->getExpiryDateTime()->getTimestamp())
+            ->setSubject($userEntity->getIdentifier())
+        ;
+
+        // Need a claim factory here to reduce the number of claims by provided scope.
+        $claims = $this->claimExtractor->extract($accessToken->getScopes(), $userEntity->getClaims());
+
+        foreach ($claims as $claimName => $claimValue) {
+            $builder->set($claimName, $claimValue);
+        }
+
+        $token = $builder
+            ->sign(new Sha256(), new Key($this->privateKey->getKeyPath(), $this->privateKey->getPassPhrase()))
+            ->getToken();
+
+        return [
+            'id_token' => (string) $token,
+        ];
+    }
+
+    /**
+     * @param ScopeEntityInterface[] $scopes
+     *
+     * @return bool
+     */
+    private function isOpenIDRequest($scopes)
+    {
+        // Verify scope and make sure openid exists.
+        $valid = false;
+
+        foreach ($scopes as $scope) {
+            if ('openid' === $scope->getIdentifier()) {
+                $valid = true;
+                break;
+            }
+        }
+
+        return $valid;
+    }
+}

--- a/lib/Services/Container.php
+++ b/lib/Services/Container.php
@@ -135,11 +135,11 @@ class Container implements ContainerInterface
             $clientRepository,
             $accessTokenRepository,
             $scopeRepository,
-            $userRepository,
             $this->services[AuthCodeGrant::class],
             $this->services[ImplicitGrant::class],
             $this->services[RefreshTokenGrant::class],
             $accessTokenDuration,
+            $idTokenResponseFactory,
             $passPhrase
         );
         $this->services[AuthorizationServer::class] = $authorizationServerFactory->build();

--- a/lib/Services/Container.php
+++ b/lib/Services/Container.php
@@ -28,6 +28,7 @@ use SimpleSAML\Modules\OpenIDConnect\Factories\FormFactory;
 use SimpleSAML\Modules\OpenIDConnect\Factories\Grant\AuthCodeGrantFactory;
 use SimpleSAML\Modules\OpenIDConnect\Factories\Grant\ImplicitGrantFactory;
 use SimpleSAML\Modules\OpenIDConnect\Factories\Grant\RefreshTokenGrantFactory;
+use SimpleSAML\Modules\OpenIDConnect\Factories\IdTokenResponseFactory;
 use SimpleSAML\Modules\OpenIDConnect\Factories\ResourceServerFactory;
 use SimpleSAML\Modules\OpenIDConnect\Factories\TemplateFactory;
 use SimpleSAML\Modules\OpenIDConnect\Repositories\AccessTokenRepository;
@@ -103,6 +104,12 @@ class Container implements ContainerInterface
         $refreshTokenDuration = new \DateInterval($configurationService->getOpenIDConnectConfiguration()->getString('refreshTokenDuration'));
         $enablePKCE = $configurationService->getOpenIDConnectConfiguration()->getBoolean('pkce', false);
         $passPhrase = $configurationService->getOpenIDConnectConfiguration()->getString('pass_phrase', null);
+
+        $idTokenResponseFactory = new IdTokenResponseFactory(
+            $userRepository,
+            $configurationService
+        );
+        $this->services[IdTokenResponseFactory::class] = $idTokenResponseFactory;
 
         $authCodeGrantFactory = new AuthCodeGrantFactory(
             $authCodeRepository,

--- a/lib/Services/JsonWebKeySetService.php
+++ b/lib/Services/JsonWebKeySetService.php
@@ -34,6 +34,7 @@ class JsonWebKeySetService
         }
 
         $jwk = JWKFactory::createFromKeyFile($publicKeyPath, null, [
+            'kid' => 'oidc',
             'use' => 'sig',
             'alg' => 'RS256',
         ]);

--- a/spec/Controller/OpenIdConnectJwksControllerSpec.php
+++ b/spec/Controller/OpenIdConnectJwksControllerSpec.php
@@ -42,6 +42,7 @@ class OpenIdConnectJwksControllerSpec extends ObjectBehavior
                 'n' => 'n',
                 'e' => 'e',
                 'use' => 'sig',
+                'kid' => 'oidc',
                 'alg' => 'RS256',
             ],
         ];

--- a/tests/Services/JsonWebKeySetServiceTest.php
+++ b/tests/Services/JsonWebKeySetServiceTest.php
@@ -60,6 +60,7 @@ class JsonWebKeySetServiceTest extends TestCase
         \SimpleSAML_Configuration::loadFromArray($config, '', 'simplesaml');
 
         $jwk = JWKFactory::createFromKey(self::$pkGeneratePublic, null, [
+            'kid' => 'oidc',
             'use' => 'sig',
             'alg' => 'RS256',
         ]);


### PR DESCRIPTION
Original `IdTokenResponse` class does not support modify the header or registered claims in token. I did a fork until original project support it. 

Now, we can add extra claims and header like real issuer and key id used in JWT KeySet.

Closes #15 and closes #16 