### PR TITLE
Updates to support last SimpleSAMLphp version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,13 +29,13 @@
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^2.10",
-        "leanphp/phpspec-code-coverage": "^4.2",
+        "friends-of-phpspec/phpspec-code-coverage": "^4.3",
         "php-coveralls/php-coveralls": "^2.0",
         "phpspec/phpspec": "^4.3",
         "phpunit/php-code-coverage": "^6.0",
         "phpunit/phpcov": "^5.0",
         "phpunit/phpunit": "^7.0",
-        "simplesamlphp/simplesamlphp": "^1.15",
+        "simplesamlphp/simplesamlphp": "^1.18"
     },
     "config": {
         "preferred-install": {

--- a/composer.json
+++ b/composer.json
@@ -18,6 +18,7 @@
     ],
     "require": {
         "php": ">=7.1.0",
+        "ext-openssl": "*",
         "league/oauth2-server": "^7.0",
         "nette/forms": "^2.4",
         "psr/container": "^1.0",
@@ -34,7 +35,7 @@
         "phpunit/php-code-coverage": "^6.0",
         "phpunit/phpcov": "^5.0",
         "phpunit/phpunit": "^7.0",
-        "simplesamlphp/simplesamlphp": "^1.15"
+        "simplesamlphp/simplesamlphp": "^1.15",
     },
     "config": {
         "preferred-install": {

--- a/hooks/hook_cron.php
+++ b/hooks/hook_cron.php
@@ -18,7 +18,7 @@ function oidc_hook_cron(&$croninfo)
     assert('array_key_exists("summary", $croninfo)');
     assert('array_key_exists("tag", $croninfo)');
 
-    $oidcConfig = SimpleSAML_Configuration::getConfig('module_oidc.php');
+    $oidcConfig = \SimpleSAML\Configuration::getConfig('module_oidc.php');
 
     if (null === $oidcConfig->getValue('cron_tag', 'hourly')) {
         return;

--- a/hooks/hook_frontpage.php
+++ b/hooks/hook_frontpage.php
@@ -21,7 +21,7 @@ function oidc_hook_frontpage(&$links)
 
     if (!$isUpdated) {
         $links['federation']['oidcregistry'] = [
-            'href' => \SimpleSAML_Module::getModuleURL('oidc/install.php'),
+            'href' => \SimpleSAML\Module::getModuleURL('oidc/install.php'),
             'text' => [
                 'en' => 'OpenID Connect Installation',
                 'es' => 'Instalación de OpenID Connect',
@@ -38,7 +38,7 @@ function oidc_hook_frontpage(&$links)
     }
 
     $links['federation']['oidcregistry'] = [
-        'href' => \SimpleSAML_Module::getModuleURL('oidc/clients/'),
+        'href' => \SimpleSAML\Module::getModuleURL('oidc/clients/'),
         'text' => [
             'en' => 'OpenID Connect Client Registry',
             'es' => 'Registro de clientes OpenID Connect',

--- a/lib/ClaimTranslatorExtractor.php
+++ b/lib/ClaimTranslatorExtractor.php
@@ -110,7 +110,7 @@ class ClaimTranslatorExtractor extends ClaimExtractor
 
         foreach ($this->translationTable as $claim => $samlMatches) {
             foreach ($samlMatches as $samlMatch) {
-                if (array_key_exists($samlMatch, $samlAttributes)) {
+                if (\array_key_exists($samlMatch, $samlAttributes)) {
                     $claims[$claim] = current($samlAttributes[$samlMatch]);
                     break;
                 }

--- a/lib/Controller/ClientDeleteController.php
+++ b/lib/Controller/ClientDeleteController.php
@@ -14,6 +14,7 @@
 
 namespace SimpleSAML\Modules\OpenIDConnect\Controller;
 
+use SimpleSAML\Error\BadRequest;
 use SimpleSAML\Modules\OpenIDConnect\Controller\Traits\GetClientFromRequestTrait;
 use SimpleSAML\Modules\OpenIDConnect\Factories\TemplateFactory;
 use SimpleSAML\Modules\OpenIDConnect\Repositories\ClientRepository;
@@ -53,11 +54,11 @@ class ClientDeleteController
 
         if ('POST' === mb_strtoupper($request->getMethod())) {
             if (!$clientSecret) {
-                throw new \SimpleSAML_Error_BadRequest('Client secret is missing.');
+                throw new BadRequest('Client secret is missing.');
             }
 
             if ($clientSecret !== $client->getSecret()) {
-                throw new \SimpleSAML_Error_BadRequest('Client secret is invalid.');
+                throw new BadRequest('Client secret is invalid.');
             }
 
             $this->clientRepository->delete($client);

--- a/lib/Controller/ClientResetSecretController.php
+++ b/lib/Controller/ClientResetSecretController.php
@@ -14,6 +14,7 @@
 
 namespace SimpleSAML\Modules\OpenIDConnect\Controller;
 
+use SimpleSAML\Error\BadRequest;
 use SimpleSAML\Modules\OpenIDConnect\Controller\Traits\GetClientFromRequestTrait;
 use SimpleSAML\Modules\OpenIDConnect\Repositories\ClientRepository;
 use SimpleSAML\Modules\OpenIDConnect\Services\SessionMessagesService;
@@ -45,11 +46,11 @@ class ClientResetSecretController
 
         if ('POST' === mb_strtoupper($request->getMethod())) {
             if (!$clientSecret) {
-                throw new \SimpleSAML_Error_BadRequest('Client secret is missing.');
+                throw new BadRequest('Client secret is missing.');
             }
 
             if ($clientSecret !== $client->getSecret()) {
-                throw new \SimpleSAML_Error_BadRequest('Client secret is invalid.');
+                throw new BadRequest('Client secret is invalid.');
             }
 
             $client->restoreSecret(Random::generateID());

--- a/lib/Controller/Traits/GetClientFromRequestTrait.php
+++ b/lib/Controller/Traits/GetClientFromRequestTrait.php
@@ -14,6 +14,8 @@
 
 namespace SimpleSAML\Modules\OpenIDConnect\Controller\Traits;
 
+use SimpleSAML\Error\BadRequest;
+use SimpleSAML\Error\NotFound;
 use SimpleSAML\Modules\OpenIDConnect\Entity\ClientEntity;
 use SimpleSAML\Modules\OpenIDConnect\Repositories\ClientRepository;
 use Zend\Diactoros\ServerRequest;
@@ -26,8 +28,8 @@ trait GetClientFromRequestTrait
     protected $clientRepository;
 
     /**
-     * @throws \SimpleSAML_Error_BadRequest
-     * @throws \SimpleSAML_Error_NotFound
+     * @throws BadRequest
+     * @throws NotFound
      *
      * @return ClientEntity
      */
@@ -37,12 +39,12 @@ trait GetClientFromRequestTrait
         $clientId = $params['client_id'] ?? null;
 
         if (!$clientId) {
-            throw new \SimpleSAML_Error_BadRequest('Client id is missing.');
+            throw new BadRequest('Client id is missing.');
         }
 
         $client = $this->clientRepository->findById($clientId);
         if (!$client) {
-            throw new \SimpleSAML_Error_NotFound('Client not found.');
+            throw new NotFound('Client not found.');
         }
 
         return $client;

--- a/lib/Controller/Traits/GetClientFromRequestTrait.php
+++ b/lib/Controller/Traits/GetClientFromRequestTrait.php
@@ -26,8 +26,6 @@ trait GetClientFromRequestTrait
     protected $clientRepository;
 
     /**
-     * @param ServerRequest $request
-     *
      * @throws \SimpleSAML_Error_BadRequest
      * @throws \SimpleSAML_Error_NotFound
      *

--- a/lib/Entity/AccessTokenEntity.php
+++ b/lib/Entity/AccessTokenEntity.php
@@ -26,7 +26,10 @@ use SimpleSAML\Modules\OpenIDConnect\Utils\TimestampGenerator;
 
 class AccessTokenEntity implements AccessTokenEntityInterface, MementoInterface
 {
-    use AccessTokenTrait, TokenEntityTrait, EntityTrait, RevokeTokenTrait;
+    use AccessTokenTrait;
+    use TokenEntityTrait;
+    use EntityTrait;
+    use RevokeTokenTrait;
 
     private function __construct()
     {
@@ -35,9 +38,7 @@ class AccessTokenEntity implements AccessTokenEntityInterface, MementoInterface
     /**
      * Create new Access Token from data.
      *
-     * @param ClientEntityInterface      $clientEntity
      * @param array|ScopeEntityInterface $scopes
-     * @param string|null                $userIdentifier
      *
      * @return AccessTokenEntity
      */

--- a/lib/Entity/AuthCodeEntity.php
+++ b/lib/Entity/AuthCodeEntity.php
@@ -24,7 +24,10 @@ use SimpleSAML\Modules\OpenIDConnect\Utils\TimestampGenerator;
 
 class AuthCodeEntity implements AuthCodeEntityInterface, MementoInterface
 {
-    use EntityTrait, TokenEntityTrait, AuthCodeTrait, RevokeTokenTrait;
+    use EntityTrait;
+    use TokenEntityTrait;
+    use AuthCodeTrait;
+    use RevokeTokenTrait;
 
     public static function fromState(array $state)
     {

--- a/lib/Entity/ClientEntity.php
+++ b/lib/Entity/ClientEntity.php
@@ -128,9 +128,6 @@ class ClientEntity implements ClientEntityInterface, MementoInterface
         ];
     }
 
-    /**
-     * @return string
-     */
     public function getSecret(): string
     {
         return $this->secret;
@@ -143,33 +140,21 @@ class ClientEntity implements ClientEntityInterface, MementoInterface
         return $this;
     }
 
-    /**
-     * @return string
-     */
     public function getDescription(): string
     {
         return $this->description;
     }
 
-    /**
-     * @return string
-     */
     public function getAuthSource(): string
     {
         return $this->authSource;
     }
 
-    /**
-     * @return array
-     */
     public function getScopes(): array
     {
         return $this->scopes;
     }
 
-    /**
-     * @return bool
-     */
     public function isEnabled(): bool
     {
         return $this->isEnabled;

--- a/lib/Entity/Interfaces/MementoInterface.php
+++ b/lib/Entity/Interfaces/MementoInterface.php
@@ -17,14 +17,9 @@ namespace SimpleSAML\Modules\OpenIDConnect\Entity\Interfaces;
 interface MementoInterface
 {
     /**
-     * @param array $state
-     *
      * @return self
      */
     public static function fromState(array $state);
 
-    /**
-     * @return array
-     */
     public function getState(): array;
 }

--- a/lib/Entity/RefreshTokenEntity.php
+++ b/lib/Entity/RefreshTokenEntity.php
@@ -23,7 +23,9 @@ use SimpleSAML\Modules\OpenIDConnect\Utils\TimestampGenerator;
 
 class RefreshTokenEntity implements RefreshTokenEntityInterface, MementoInterface
 {
-    use RefreshTokenTrait, EntityTrait, RevokeTokenTrait;
+    use RefreshTokenTrait;
+    use EntityTrait;
+    use RevokeTokenTrait;
 
     public static function fromState(array $state)
     {

--- a/lib/Entity/Traits/RevokeTokenTrait.php
+++ b/lib/Entity/Traits/RevokeTokenTrait.php
@@ -21,9 +21,6 @@ trait RevokeTokenTrait
      */
     protected $isRevoked = 0;
 
-    /**
-     * @return bool
-     */
     public function isRevoked(): bool
     {
         return (bool) $this->isRevoked;

--- a/lib/Factories/FormFactory.php
+++ b/lib/Factories/FormFactory.php
@@ -15,6 +15,7 @@
 namespace SimpleSAML\Modules\OpenIDConnect\Factories;
 
 use Nette\Forms\Form;
+use SimpleSAML\Error\Exception;
 use SimpleSAML\Modules\OpenIDConnect\Services\ConfigurationService;
 
 class FormFactory
@@ -32,7 +33,7 @@ class FormFactory
     /**
      * @param string $name Form name
      *
-     * @throws \SimpleSAML_Error_Exception
+     * @throws Exception
      *
      * @return mixed
      */
@@ -40,7 +41,7 @@ class FormFactory
     {
         if (!class_exists($classname)
             && $classname instanceof Form) {
-            throw new \SimpleSAML_Error_Exception("Invalid form: {$classname}");
+            throw new Exception("Invalid form: {$classname}");
         }
 
         return new $classname($this->configurationService);

--- a/lib/Factories/TemplateFactory.php
+++ b/lib/Factories/TemplateFactory.php
@@ -14,24 +14,27 @@
 
 namespace SimpleSAML\Modules\OpenIDConnect\Factories;
 
+use SimpleSAML\Configuration;
+use SimpleSAML\XHTML\Template;
+
 class TemplateFactory
 {
     /**
-     * @var \SimpleSAML\Configuration
+     * @var Configuration
      */
     private $configuration;
 
-    public function __construct(\SimpleSAML\Configuration $configuration)
+    public function __construct(Configuration $configuration)
     {
         $config = $configuration->toArray();
         $config['usenewui'] = true;
 
-        $this->configuration = new \SimpleSAML\Configuration($config, 'oidc');
+        $this->configuration = new Configuration($config, 'oidc');
     }
 
-    public function render(string $templateName, array $data = []): \SimpleSAML\XHTML\Template
+    public function render(string $templateName, array $data = []): Template
     {
-        $template = new \SimpleSAML\XHTML\Template($this->configuration, $templateName);
+        $template = new Template($this->configuration, $templateName);
         $template->data += $data;
 
         return $template;

--- a/lib/Factories/TemplateFactory.php
+++ b/lib/Factories/TemplateFactory.php
@@ -17,18 +17,21 @@ namespace SimpleSAML\Modules\OpenIDConnect\Factories;
 class TemplateFactory
 {
     /**
-     * @var \SimpleSAML_Configuration
+     * @var \SimpleSAML\Configuration
      */
     private $configuration;
 
-    public function __construct(\SimpleSAML_Configuration $configuration)
+    public function __construct(\SimpleSAML\Configuration $configuration)
     {
-        $this->configuration = $configuration;
+        $config = $configuration->toArray();
+        $config['usenewui'] = true;
+
+        $this->configuration = new \SimpleSAML\Configuration($config, 'oidc');
     }
 
-    public function render(string $templateName, array $data = []): \SimpleSAML_XHTML_Template
+    public function render(string $templateName, array $data = []): \SimpleSAML\XHTML\Template
     {
-        $template = new \SimpleSAML_XHTML_Template($this->configuration, $templateName);
+        $template = new \SimpleSAML\XHTML\Template($this->configuration, $templateName);
         $template->data += $data;
 
         return $template;

--- a/lib/Form/ClientForm.php
+++ b/lib/Form/ClientForm.php
@@ -15,6 +15,7 @@
 namespace SimpleSAML\Modules\OpenIDConnect\Form;
 
 use Nette\Forms\Form;
+use SimpleSAML\Auth\Source;
 use SimpleSAML\Modules\OpenIDConnect\Services\ConfigurationService;
 
 class ClientForm extends Form
@@ -110,7 +111,7 @@ class ClientForm extends Form
 
         $this->addSelect('auth_source', '{oidc:client:auth_source}:')
             ->setAttribute('class', 'ui fluid dropdown')
-            ->setItems(\SimpleSAML_Auth_Source::getSources(), false)
+            ->setItems(Source::getSources(), false)
             ->setPrompt('Pick an AuthSource')
             ->setRequired('Select one Auth Source');
 

--- a/lib/Form/ClientForm.php
+++ b/lib/Form/ClientForm.php
@@ -122,9 +122,6 @@ class ClientForm extends Form
             ->setRequired('Select one scope at least');
     }
 
-    /**
-     * @return array
-     */
     protected function getScopes(): array
     {
         $items = array_map(function ($item) {

--- a/lib/Form/Controls/CsrfProtection.php
+++ b/lib/Form/Controls/CsrfProtection.php
@@ -15,6 +15,7 @@
 namespace SimpleSAML\Modules\OpenIDConnect\Form\Controls;
 
 use Nette\Forms\Controls\CsrfProtection as BaseCsrfProtection;
+use SimpleSAML\Session;
 use SimpleSAML\Utils\Random;
 
 class CsrfProtection extends BaseCsrfProtection
@@ -23,7 +24,7 @@ class CsrfProtection extends BaseCsrfProtection
     {
         parent::__construct($errorMessage);
 
-        $this->session = \SimpleSAML_Session::getSession();
+        $this->session = Session::getSession();
     }
 
     public function getToken()

--- a/lib/Repositories/AbstractDatabaseRepository.php
+++ b/lib/Repositories/AbstractDatabaseRepository.php
@@ -14,13 +14,14 @@
 
 namespace SimpleSAML\Modules\OpenIDConnect\Repositories;
 
+use SimpleSAML\Configuration;
 use SimpleSAML\Database;
 use SimpleSAML\Modules\OpenIDConnect\Services\ConfigurationService;
 
 abstract class AbstractDatabaseRepository
 {
     /**
-     * @var \SimpleSAML_Configuration
+     * @var Configuration
      */
     protected $config;
     /**
@@ -37,7 +38,7 @@ abstract class AbstractDatabaseRepository
      */
     public function __construct(ConfigurationService $configurationService = null)
     {
-        $this->config = \SimpleSAML_Configuration::getOptionalConfig('module_oidc.php');
+        $this->config = Configuration::getOptionalConfig('module_oidc.php');
         $this->database = Database::getInstance();
         $this->configurationService = $configurationService;
     }

--- a/lib/Repositories/AccessTokenRepository.php
+++ b/lib/Repositories/AccessTokenRepository.php
@@ -56,7 +56,7 @@ class AccessTokenRepository extends AbstractDatabaseRepository implements Access
      *
      * @param $tokenId
      *
-     * @return null|AccessTokenEntity
+     * @return AccessTokenEntity|null
      */
     public function findById($tokenId)
     {

--- a/lib/Repositories/AuthCodeRepository.php
+++ b/lib/Repositories/AuthCodeRepository.php
@@ -46,7 +46,7 @@ class AuthCodeRepository extends AbstractDatabaseRepository implements AuthCodeR
      *
      * @param $codeId
      *
-     * @return null|AuthCodeEntityInterface
+     * @return AuthCodeEntityInterface|null
      */
     public function findById($codeId)
     {

--- a/lib/Repositories/RefreshTokenRepository.php
+++ b/lib/Repositories/RefreshTokenRepository.php
@@ -49,7 +49,7 @@ class RefreshTokenRepository extends AbstractDatabaseRepository implements Refre
      *
      * @param $tokenId
      *
-     * @return null|RefreshTokenEntity
+     * @return RefreshTokenEntity|null
      */
     public function findById($tokenId)
     {

--- a/lib/Repositories/ScopeRepository.php
+++ b/lib/Repositories/ScopeRepository.php
@@ -36,7 +36,7 @@ class ScopeRepository extends AbstractDatabaseRepository implements ScopeReposit
     {
         $scopes = $this->configurationService->getOpenIDScopes();
 
-        if (false === array_key_exists($identifier, $scopes)) {
+        if (false === \array_key_exists($identifier, $scopes)) {
             return null;
         }
 

--- a/lib/Server/ResponseTypes/IdTokenResponse.php
+++ b/lib/Server/ResponseTypes/IdTokenResponse.php
@@ -60,8 +60,6 @@ class IdTokenResponse extends BearerTokenResponse
     }
 
     /**
-     * @param AccessTokenEntityInterface $accessToken
-     *
      * @return array
      */
     protected function getExtraParams(AccessTokenEntityInterface $accessToken)

--- a/lib/Services/AuthenticationService.php
+++ b/lib/Services/AuthenticationService.php
@@ -14,6 +14,7 @@
 
 namespace SimpleSAML\Modules\OpenIDConnect\Services;
 
+use SimpleSAML\Error\Exception;
 use SimpleSAML\Modules\OpenIDConnect\Entity\UserEntity;
 use SimpleSAML\Modules\OpenIDConnect\Factories\AuthSimpleFactory;
 use SimpleSAML\Modules\OpenIDConnect\Repositories\UserRepository;
@@ -44,7 +45,7 @@ class AuthenticationService
     }
 
     /**
-     * @throws \SimpleSAML_Error_Exception
+     * @throws Exception
      */
     public function getAuthenticateUser(string $authSource): UserEntity
     {
@@ -53,7 +54,7 @@ class AuthenticationService
 
         $claims = $authSimple->getAttributes();
         if (!\array_key_exists($this->userIdAttr, $claims)) {
-            throw new \SimpleSAML_Error_Exception('Attribute `useridattr` doesn\'t exists in claims. Available attributes are: '.implode(', ', array_keys($claims)));
+            throw new Exception('Attribute `useridattr` doesn\'t exists in claims. Available attributes are: '.implode(', ', array_keys($claims)));
         }
 
         $userId = $claims[$this->userIdAttr][0];

--- a/lib/Services/AuthenticationService.php
+++ b/lib/Services/AuthenticationService.php
@@ -44,11 +44,7 @@ class AuthenticationService
     }
 
     /**
-     * @param string $authSource
-     *
      * @throws \SimpleSAML_Error_Exception
-     *
-     * @return UserEntity
      */
     public function getAuthenticateUser(string $authSource): UserEntity
     {
@@ -56,7 +52,7 @@ class AuthenticationService
         $authSimple->requireAuth();
 
         $claims = $authSimple->getAttributes();
-        if (!array_key_exists($this->userIdAttr, $claims)) {
+        if (!\array_key_exists($this->userIdAttr, $claims)) {
             throw new \SimpleSAML_Error_Exception('Attribute `useridattr` doesn\'t exists in claims. Available attributes are: '.implode(', ', array_keys($claims)));
         }
 

--- a/lib/Services/ConfigurationService.php
+++ b/lib/Services/ConfigurationService.php
@@ -14,6 +14,7 @@
 
 namespace SimpleSAML\Modules\OpenIDConnect\Services;
 
+use SimpleSAML\Configuration;
 use SimpleSAML\Error\ConfigurationError;
 use SimpleSAML\Module;
 use SimpleSAML\Utils\HTTP;
@@ -43,14 +44,14 @@ class ConfigurationService
         $this->validateConfiguration();
     }
 
-    public function getSimpleSAMLConfiguration(): \SimpleSAML_Configuration
+    public function getSimpleSAMLConfiguration(): Configuration
     {
-        return \SimpleSAML_Configuration::getInstance();
+        return Configuration::getInstance();
     }
 
-    public function getOpenIDConnectConfiguration(): \SimpleSAML_Configuration
+    public function getOpenIDConnectConfiguration(): Configuration
     {
-        return \SimpleSAML_Configuration::getConfig('module_oidc.php');
+        return Configuration::getConfig('module_oidc.php');
     }
 
     public function getSimpleSAMLSelfURLHost()

--- a/lib/Services/ConfigurationService.php
+++ b/lib/Services/ConfigurationService.php
@@ -88,7 +88,7 @@ class ConfigurationService
             if (\in_array($name, ['openid', 'profile', 'email', 'address', 'phone'], true)) {
                 throw new ConfigurationError('Protected scope can be overwrited: '.$name, 'oidc_config.php');
             }
-            if (!array_key_exists('description', $scope)) {
+            if (!\array_key_exists('description', $scope)) {
                 throw new ConfigurationError('Scope ['.$name.'] description not defined', 'module_oidc.php');
             }
         });

--- a/lib/Services/Container.php
+++ b/lib/Services/Container.php
@@ -182,6 +182,6 @@ class Container implements ContainerInterface
 
     public function has($id)
     {
-        return array_key_exists($id, $this->services);
+        return \array_key_exists($id, $this->services);
     }
 }

--- a/lib/Services/Container.php
+++ b/lib/Services/Container.php
@@ -21,7 +21,9 @@ use League\OAuth2\Server\Grant\RefreshTokenGrant;
 use League\OAuth2\Server\ResourceServer;
 use Psr\Container\ContainerInterface;
 use Psr\Container\NotFoundExceptionInterface;
+use SimpleSAML\Configuration;
 use SimpleSAML\Database;
+use SimpleSAML\Error\Exception;
 use SimpleSAML\Modules\OpenIDConnect\ClaimTranslatorExtractor;
 use SimpleSAML\Modules\OpenIDConnect\Factories\AuthorizationServerFactory;
 use SimpleSAML\Modules\OpenIDConnect\Factories\AuthSimpleFactory;
@@ -39,6 +41,7 @@ use SimpleSAML\Modules\OpenIDConnect\Repositories\ClientRepository;
 use SimpleSAML\Modules\OpenIDConnect\Repositories\RefreshTokenRepository;
 use SimpleSAML\Modules\OpenIDConnect\Repositories\ScopeRepository;
 use SimpleSAML\Modules\OpenIDConnect\Repositories\UserRepository;
+use SimpleSAML\Session;
 
 class Container implements ContainerInterface
 {
@@ -46,8 +49,8 @@ class Container implements ContainerInterface
 
     public function __construct()
     {
-        $simpleSAMLConfiguration = \SimpleSAML_Configuration::getInstance();
-        $oidcModuleConfiguration = \SimpleSAML_Configuration::getConfig('module_oidc.php');
+        $simpleSAMLConfiguration = Configuration::getInstance();
+        $oidcModuleConfiguration = Configuration::getConfig('module_oidc.php');
 
         $configurationService = new ConfigurationService();
         $this->services[ConfigurationService::class] = $configurationService;
@@ -88,7 +91,7 @@ class Container implements ContainerInterface
         $jsonWebKeySetService = new JsonWebKeySetService();
         $this->services[JsonWebKeySetService::class] = $jsonWebKeySetService;
 
-        $sessionMessagesService = new SessionMessagesService(\SimpleSAML_Session::getSessionFromRequest());
+        $sessionMessagesService = new SessionMessagesService(Session::getSessionFromRequest());
         $this->services[SessionMessagesService::class] = $sessionMessagesService;
 
         $templateFactory = new TemplateFactory($simpleSAMLConfiguration);
@@ -162,14 +165,14 @@ class Container implements ContainerInterface
      * @param string $id
      *
      * @throws NotFoundExceptionInterface
-     * @throws \SimpleSAML_Error_Exception
+     * @throws Exception
      *
      * @return object
      */
     public function get($id)
     {
         if (false === $this->has($id)) {
-            throw new class($id) extends \SimpleSAML_Error_Exception implements NotFoundExceptionInterface {
+            throw new class($id) extends Exception implements NotFoundExceptionInterface {
                 public function __construct(string $id)
                 {
                     parent::__construct("Service not found: {$id}.");

--- a/lib/Services/DatabaseMigration.php
+++ b/lib/Services/DatabaseMigration.php
@@ -75,9 +75,6 @@ class DatabaseMigration
         }
     }
 
-    /**
-     * @return string
-     */
     private function versionsTableName(): string
     {
         $versionsTablename = $this->database->applyPrefix('oidc_migration_versions');

--- a/lib/Services/JsonWebKeySetService.php
+++ b/lib/Services/JsonWebKeySetService.php
@@ -16,6 +16,7 @@ namespace SimpleSAML\Modules\OpenIDConnect\Services;
 
 use Jose\Factory\JWKFactory;
 use Jose\Object\JWKSet;
+use SimpleSAML\Error\Exception;
 use SimpleSAML\Utils\Config;
 
 class JsonWebKeySetService
@@ -30,7 +31,7 @@ class JsonWebKeySetService
         $publicKeyPath = Config::getCertPath('oidc_module.crt');
 
         if (!file_exists($publicKeyPath)) {
-            throw new \SimpleSAML_Error_Error("OpenId Connect certification file does not exists: {$publicKeyPath}.");
+            throw new Exception("OpenId Connect certification file does not exists: {$publicKeyPath}.");
         }
 
         $jwk = JWKFactory::createFromKeyFile($publicKeyPath, null, [

--- a/lib/Services/RoutingService.php
+++ b/lib/Services/RoutingService.php
@@ -17,7 +17,10 @@ namespace SimpleSAML\Modules\OpenIDConnect\Services;
 use League\OAuth2\Server\Exception\OAuthServerException;
 use Psr\Container\ContainerInterface;
 use Psr\Http\Message\ResponseInterface;
+use SimpleSAML\Error\BadRequest;
+use SimpleSAML\Error\Exception;
 use SimpleSAML\Utils\Auth;
+use SimpleSAML\XHTML\Template;
 use Zend\Diactoros\Response;
 use Zend\Diactoros\Response\JsonResponse;
 use Zend\Diactoros\Response\SapiEmitter;
@@ -43,7 +46,7 @@ class RoutingService
         /** @var callable $controller */
         $response = $controller($serverRequest);
 
-        if ($response instanceof \SimpleSAML\XHTML\Template) {
+        if ($response instanceof Template) {
             $response->data['messages'] = $container->get(SessionMessagesService::class)->getMessages();
 
             return $response->show();
@@ -55,13 +58,13 @@ class RoutingService
             return $emitter->emit($response);
         }
 
-        throw new \SimpleSAML_Error_Error('Response type not supported: '.\get_class($response));
+        throw new Exception('Response type not supported: '.\get_class($response));
     }
 
     protected static function getController(string $controllerClassname, ContainerInterface $container)
     {
         if (!class_exists($controllerClassname)) {
-            throw new \SimpleSAML_Error_BadRequest("Controller does not exist: {$controllerClassname}");
+            throw new BadRequest("Controller does not exist: {$controllerClassname}");
         }
         $controllerReflectionClass = new \ReflectionClass($controllerClassname);
 

--- a/lib/Services/RoutingService.php
+++ b/lib/Services/RoutingService.php
@@ -43,7 +43,7 @@ class RoutingService
         /** @var callable $controller */
         $response = $controller($serverRequest);
 
-        if ($response instanceof \SimpleSAML_XHTML_Template) {
+        if ($response instanceof \SimpleSAML\XHTML\Template) {
             $response->data['messages'] = $container->get(SessionMessagesService::class)->getMessages();
 
             return $response->show();

--- a/lib/Services/SessionMessagesService.php
+++ b/lib/Services/SessionMessagesService.php
@@ -14,11 +14,13 @@
 
 namespace SimpleSAML\Modules\OpenIDConnect\Services;
 
+use SimpleSAML\Session;
+
 class SessionMessagesService
 {
     private $session;
 
-    public function __construct(\SimpleSAML_Session $session)
+    public function __construct(Session $session)
     {
         $this->session = $session;
     }

--- a/locales/en/LC_MESSAGES/oidc.po
+++ b/locales/en/LC_MESSAGES/oidc.po
@@ -114,3 +114,6 @@ msgstr "Old oauth2 module clients has been imported."
 
 msgid "{oidc:client:is_enabled}"
 msgstr "Activated"
+
+msgid "{oidc:title}"
+msgstr "OpenID Connect Client Registry"

--- a/locales/es/LC_MESSAGES/oidc.po
+++ b/locales/es/LC_MESSAGES/oidc.po
@@ -117,3 +117,6 @@ msgstr "Los clientes del módulo oauth2 han sido importados."
 
 msgid "{oidc:client:is_enabled}"
 msgstr "Activado"
+
+msgid "{oidc:oidc:title}"
+msgstr "Registro de clientes OpenID Connect"

--- a/phpspec.yml.dist
+++ b/phpspec.yml.dist
@@ -4,7 +4,7 @@ suites:
         namespace: SimpleSAML\Modules\OpenIDConnect
         psr4_prefix: SimpleSAML\Modules\OpenIDConnect
 extensions:
-    LeanPHP\PhpSpec\CodeCoverage\CodeCoverageExtension:
+    FriendsOfPhpSpec\PhpSpec\CodeCoverage\CodeCoverageExtension:
         format:
             - 'php'
         output:

--- a/spec/Controller/ClientCreateControllerSpec.php
+++ b/spec/Controller/ClientCreateControllerSpec.php
@@ -17,6 +17,7 @@ namespace spec\SimpleSAML\Modules\OpenIDConnect\Controller;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
 use Psr\Http\Message\UriInterface;
+use SimpleSAML\Configuration;
 use SimpleSAML\Modules\OpenIDConnect\Controller\ClientCreateController;
 use SimpleSAML\Modules\OpenIDConnect\Entity\ClientEntity;
 use SimpleSAML\Modules\OpenIDConnect\Factories\FormFactory;
@@ -24,6 +25,7 @@ use SimpleSAML\Modules\OpenIDConnect\Factories\TemplateFactory;
 use SimpleSAML\Modules\OpenIDConnect\Form\ClientForm;
 use SimpleSAML\Modules\OpenIDConnect\Repositories\ClientRepository;
 use SimpleSAML\Modules\OpenIDConnect\Services\SessionMessagesService;
+use SimpleSAML\XHTML\Template;
 use Zend\Diactoros\Response\RedirectResponse;
 use Zend\Diactoros\ServerRequest;
 
@@ -38,7 +40,7 @@ class ClientCreateControllerSpec extends ObjectBehavior
         UriInterface $uri
     ) {
         $_SERVER['REQUEST_URI'] = '/';
-        \SimpleSAML_Configuration::loadFromArray([], '', 'simplesaml');
+        Configuration::loadFromArray([], '', 'simplesaml');
 
         $request->getUri()->willReturn($uri);
         $uri->getPath()->willReturn('/');
@@ -53,7 +55,7 @@ class ClientCreateControllerSpec extends ObjectBehavior
 
     public function it_shows_new_client_form(
         ServerRequest $request,
-        \SimpleSAML_XHTML_Template $template,
+        Template $template,
         TemplateFactory $templateFactory,
         FormFactory $formFactory,
         ClientForm $clientForm

--- a/spec/Controller/ClientDeleteControllerSpec.php
+++ b/spec/Controller/ClientDeleteControllerSpec.php
@@ -16,11 +16,15 @@ namespace spec\SimpleSAML\Modules\OpenIDConnect\Controller;
 
 use PhpSpec\ObjectBehavior;
 use Psr\Http\Message\UriInterface;
+use SimpleSAML\Configuration;
+use SimpleSAML\Error\BadRequest;
+use SimpleSAML\Error\NotFound;
 use SimpleSAML\Modules\OpenIDConnect\Controller\ClientDeleteController;
 use SimpleSAML\Modules\OpenIDConnect\Entity\ClientEntity;
 use SimpleSAML\Modules\OpenIDConnect\Factories\TemplateFactory;
 use SimpleSAML\Modules\OpenIDConnect\Repositories\ClientRepository;
 use SimpleSAML\Modules\OpenIDConnect\Services\SessionMessagesService;
+use SimpleSAML\XHTML\Template;
 use Zend\Diactoros\Response\RedirectResponse;
 use Zend\Diactoros\ServerRequest;
 
@@ -34,7 +38,7 @@ class ClientDeleteControllerSpec extends ObjectBehavior
         UriInterface $uri
     ) {
         $_SERVER['REQUEST_URI'] = '/';
-        \SimpleSAML_Configuration::loadFromArray([], '', 'simplesaml');
+        Configuration::loadFromArray([], '', 'simplesaml');
 
         $request->getUri()->willReturn($uri);
         $uri->getPath()->willReturn('/');
@@ -49,7 +53,7 @@ class ClientDeleteControllerSpec extends ObjectBehavior
 
     public function it_asks_confirmation_before_delete_client(
         ServerRequest $request,
-        \SimpleSAML_XHTML_Template $template,
+        Template $template,
         TemplateFactory $templateFactory,
         ClientRepository $clientRepository,
         ClientEntity $clientEntity
@@ -68,7 +72,7 @@ class ClientDeleteControllerSpec extends ObjectBehavior
     ) {
         $request->getQueryParams()->shouldBeCalled()->willReturn([]);
 
-        $this->shouldThrow(\SimpleSAML_Error_BadRequest::class)->during('__invoke', [$request]);
+        $this->shouldThrow(BadRequest::class)->during('__invoke', [$request]);
     }
 
     public function it_throws_client_not_found_exception_in_delete_action(
@@ -78,7 +82,7 @@ class ClientDeleteControllerSpec extends ObjectBehavior
         $request->getQueryParams()->shouldBeCalled()->willReturn(['client_id' => 'clientid']);
         $clientRepository->findById('clientid')->shouldBeCalled()->willReturn(null);
 
-        $this->shouldThrow(\SimpleSAML_Error_NotFound::class)->during('__invoke', [$request]);
+        $this->shouldThrow(NotFound::class)->during('__invoke', [$request]);
     }
 
     public function it_throws_secret_not_found_exception_in_delete_action(
@@ -91,7 +95,7 @@ class ClientDeleteControllerSpec extends ObjectBehavior
         $request->getParsedBody()->shouldBeCalled()->willReturn([]);
         $request->getMethod()->shouldBeCalled()->willReturn('post');
 
-        $this->shouldThrow(\SimpleSAML_Error_BadRequest::class)->during('__invoke', [$request]);
+        $this->shouldThrow(BadRequest::class)->during('__invoke', [$request]);
     }
 
     public function it_throws_secret_invalid_exception_in_delete_action(
@@ -106,7 +110,7 @@ class ClientDeleteControllerSpec extends ObjectBehavior
         $clientRepository->findById('clientid')->shouldBeCalled()->willReturn($clientEntity);
         $clientEntity->getSecret()->shouldBeCalled()->willReturn('validsecret');
 
-        $this->shouldThrow(\SimpleSAML_Error_BadRequest::class)->during('__invoke', [$request]);
+        $this->shouldThrow(BadRequest::class)->during('__invoke', [$request]);
     }
 
     public function it_deletes_client(

--- a/spec/Controller/ClientEditControllerSpec.php
+++ b/spec/Controller/ClientEditControllerSpec.php
@@ -17,6 +17,9 @@ namespace spec\SimpleSAML\Modules\OpenIDConnect\Controller;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
 use Psr\Http\Message\UriInterface;
+use SimpleSAML\Configuration;
+use SimpleSAML\Error\BadRequest;
+use SimpleSAML\Error\NotFound;
 use SimpleSAML\Modules\OpenIDConnect\Controller\ClientEditController;
 use SimpleSAML\Modules\OpenIDConnect\Entity\ClientEntity;
 use SimpleSAML\Modules\OpenIDConnect\Factories\FormFactory;
@@ -24,6 +27,7 @@ use SimpleSAML\Modules\OpenIDConnect\Factories\TemplateFactory;
 use SimpleSAML\Modules\OpenIDConnect\Form\ClientForm;
 use SimpleSAML\Modules\OpenIDConnect\Repositories\ClientRepository;
 use SimpleSAML\Modules\OpenIDConnect\Services\SessionMessagesService;
+use SimpleSAML\XHTML\Template;
 use Zend\Diactoros\Response\RedirectResponse;
 use Zend\Diactoros\ServerRequest;
 
@@ -38,7 +42,7 @@ class ClientEditControllerSpec extends ObjectBehavior
         UriInterface $uri
     ) {
         $_SERVER['REQUEST_URI'] = '/';
-        \SimpleSAML_Configuration::loadFromArray([], '', 'simplesaml');
+        Configuration::loadFromArray([], '', 'simplesaml');
 
         $request->getUri()->willReturn($uri);
         $uri->getPath()->willReturn('/');
@@ -53,7 +57,7 @@ class ClientEditControllerSpec extends ObjectBehavior
 
     public function it_shows_edit_client_form(
         ServerRequest $request,
-        \SimpleSAML_XHTML_Template $template,
+        Template $template,
         TemplateFactory $templateFactory,
         FormFactory $formFactory,
         ClientForm $clientForm,
@@ -143,7 +147,7 @@ class ClientEditControllerSpec extends ObjectBehavior
     ) {
         $request->getQueryParams()->shouldBeCalled()->willReturn([]);
 
-        $this->shouldThrow(\SimpleSAML_Error_BadRequest::class)->during('__invoke', [$request]);
+        $this->shouldThrow(BadRequest::class)->during('__invoke', [$request]);
     }
 
     public function it_throws_client_not_found_exception_in_edit_action(
@@ -153,6 +157,6 @@ class ClientEditControllerSpec extends ObjectBehavior
         $request->getQueryParams()->shouldBeCalled()->willReturn(['client_id' => 'clientid']);
         $clientRepository->findById('clientid')->shouldBeCalled()->willReturn(null);
 
-        $this->shouldThrow(\SimpleSAML_Error_NotFound::class)->during('__invoke', [$request]);
+        $this->shouldThrow(NotFound::class)->during('__invoke', [$request]);
     }
 }

--- a/spec/Controller/ClientIndexControllerSpec.php
+++ b/spec/Controller/ClientIndexControllerSpec.php
@@ -16,9 +16,11 @@ namespace spec\SimpleSAML\Modules\OpenIDConnect\Controller;
 
 use PhpSpec\ObjectBehavior;
 use Psr\Http\Message\UriInterface;
+use SimpleSAML\Configuration;
 use SimpleSAML\Modules\OpenIDConnect\Controller\ClientIndexController;
 use SimpleSAML\Modules\OpenIDConnect\Factories\TemplateFactory;
 use SimpleSAML\Modules\OpenIDConnect\Repositories\ClientRepository;
+use SimpleSAML\XHTML\Template;
 use Zend\Diactoros\ServerRequest;
 
 class ClientIndexControllerSpec extends ObjectBehavior
@@ -30,7 +32,7 @@ class ClientIndexControllerSpec extends ObjectBehavior
         UriInterface $uri
     ) {
         $_SERVER['REQUEST_URI'] = '/';
-        \SimpleSAML_Configuration::loadFromArray([], '', 'simplesaml');
+        Configuration::loadFromArray([], '', 'simplesaml');
 
         $request->getUri()->willReturn($uri);
         $uri->getPath()->willReturn('/');
@@ -45,7 +47,7 @@ class ClientIndexControllerSpec extends ObjectBehavior
 
     public function it_shows_client_index(
         ServerRequest $request,
-        \SimpleSAML_XHTML_Template $template,
+        Template $template,
         TemplateFactory $templateFactory,
         ClientRepository $clientRepository
     ) {

--- a/spec/Controller/ClientResetSecretControllerSpec.php
+++ b/spec/Controller/ClientResetSecretControllerSpec.php
@@ -17,6 +17,9 @@ namespace spec\SimpleSAML\Modules\OpenIDConnect\Controller;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
 use Psr\Http\Message\UriInterface;
+use SimpleSAML\Configuration;
+use SimpleSAML\Error\BadRequest;
+use SimpleSAML\Error\NotFound;
 use SimpleSAML\Modules\OpenIDConnect\Controller\ClientResetSecretController;
 use SimpleSAML\Modules\OpenIDConnect\Entity\ClientEntity;
 use SimpleSAML\Modules\OpenIDConnect\Repositories\ClientRepository;
@@ -33,7 +36,7 @@ class ClientResetSecretControllerSpec extends ObjectBehavior
         UriInterface $uri
     ) {
         $_SERVER['REQUEST_URI'] = '/';
-        \SimpleSAML_Configuration::loadFromArray([], '', 'simplesaml');
+        Configuration::loadFromArray([], '', 'simplesaml');
 
         $request->getUri()->willReturn($uri);
         $uri->getPath()->willReturn('/');
@@ -51,7 +54,7 @@ class ClientResetSecretControllerSpec extends ObjectBehavior
     ) {
         $request->getQueryParams()->shouldBeCalled()->willReturn([]);
 
-        $this->shouldThrow(\SimpleSAML_Error_BadRequest::class)->during('__invoke', [$request]);
+        $this->shouldThrow(BadRequest::class)->during('__invoke', [$request]);
     }
 
     public function it_throws_client_not_found_exception_in_reset_secret_action(
@@ -61,7 +64,7 @@ class ClientResetSecretControllerSpec extends ObjectBehavior
         $request->getQueryParams()->shouldBeCalled()->willReturn(['client_id' => 'clientid']);
         $clientRepository->findById('clientid')->shouldBeCalled()->willReturn(null);
 
-        $this->shouldThrow(\SimpleSAML_Error_NotFound::class)->during('__invoke', [$request]);
+        $this->shouldThrow(NotFound::class)->during('__invoke', [$request]);
     }
 
     public function it_throws_secret_not_found_exception_in_reset_secret_action(
@@ -74,7 +77,7 @@ class ClientResetSecretControllerSpec extends ObjectBehavior
         $request->getParsedBody()->shouldBeCalled()->willReturn([]);
         $request->getMethod()->shouldBeCalled()->willReturn('post');
 
-        $this->shouldThrow(\SimpleSAML_Error_BadRequest::class)->during('__invoke', [$request]);
+        $this->shouldThrow(BadRequest::class)->during('__invoke', [$request]);
     }
 
     public function it_throws_secret_invalid_exception_in_reset_secret_action(
@@ -89,7 +92,7 @@ class ClientResetSecretControllerSpec extends ObjectBehavior
         $clientRepository->findById('clientid')->shouldBeCalled()->willReturn($clientEntity);
         $clientEntity->getSecret()->shouldBeCalled()->willReturn('validsecret');
 
-        $this->shouldThrow(\SimpleSAML_Error_BadRequest::class)->during('__invoke', [$request]);
+        $this->shouldThrow(BadRequest::class)->during('__invoke', [$request]);
     }
 
     public function it_reset_secrets_client(

--- a/spec/Controller/ClientShowControllerSpec.php
+++ b/spec/Controller/ClientShowControllerSpec.php
@@ -16,10 +16,14 @@ namespace spec\SimpleSAML\Modules\OpenIDConnect\Controller;
 
 use PhpSpec\ObjectBehavior;
 use Psr\Http\Message\UriInterface;
+use SimpleSAML\Configuration;
+use SimpleSAML\Error\BadRequest;
+use SimpleSAML\Error\NotFound;
 use SimpleSAML\Modules\OpenIDConnect\Controller\ClientShowController;
 use SimpleSAML\Modules\OpenIDConnect\Entity\ClientEntity;
 use SimpleSAML\Modules\OpenIDConnect\Factories\TemplateFactory;
 use SimpleSAML\Modules\OpenIDConnect\Repositories\ClientRepository;
+use SimpleSAML\XHTML\Template;
 use Zend\Diactoros\ServerRequest;
 
 class ClientShowControllerSpec extends ObjectBehavior
@@ -31,7 +35,7 @@ class ClientShowControllerSpec extends ObjectBehavior
         UriInterface $uri
     ) {
         $_SERVER['REQUEST_URI'] = '/';
-        \SimpleSAML_Configuration::loadFromArray([], '', 'simplesaml');
+        Configuration::loadFromArray([], '', 'simplesaml');
 
         $request->getUri()->willReturn($uri);
         $uri->getPath()->willReturn('/');
@@ -46,7 +50,7 @@ class ClientShowControllerSpec extends ObjectBehavior
 
     public function it_show_client_description(
         ServerRequest $request,
-        \SimpleSAML_XHTML_Template $template,
+        Template $template,
         TemplateFactory $templateFactory,
         ClientRepository $clientRepository,
         ClientEntity $clientEntity
@@ -63,7 +67,7 @@ class ClientShowControllerSpec extends ObjectBehavior
     ) {
         $request->getQueryParams()->shouldBeCalled()->willReturn([]);
 
-        $this->shouldThrow(\SimpleSAML_Error_BadRequest::class)->during('__invoke', [$request]);
+        $this->shouldThrow(BadRequest::class)->during('__invoke', [$request]);
     }
 
     public function it_throws_client_not_found_exception_in_show_action(
@@ -73,6 +77,6 @@ class ClientShowControllerSpec extends ObjectBehavior
         $request->getQueryParams()->shouldBeCalled()->willReturn(['client_id' => 'clientid']);
         $clientRepository->findById('clientid')->shouldBeCalled()->willReturn(null);
 
-        $this->shouldThrow(\SimpleSAML_Error_NotFound::class)->during('__invoke', [$request]);
+        $this->shouldThrow(NotFound::class)->during('__invoke', [$request]);
     }
 }

--- a/spec/Controller/OpenIdConnectDiscoverConfigurationControllerSpec.php
+++ b/spec/Controller/OpenIdConnectDiscoverConfigurationControllerSpec.php
@@ -15,6 +15,7 @@
 namespace spec\SimpleSAML\Modules\OpenIDConnect\Controller;
 
 use PhpSpec\ObjectBehavior;
+use SimpleSAML\Configuration;
 use SimpleSAML\Modules\OpenIDConnect\Controller\OpenIdConnectDiscoverConfigurationController;
 use SimpleSAML\Modules\OpenIDConnect\Services\ConfigurationService;
 use Zend\Diactoros\Response\JsonResponse;
@@ -36,7 +37,7 @@ class OpenIdConnectDiscoverConfigurationControllerSpec extends ObjectBehavior
     public function it_returns_openid_connect_configuration(
         ServerRequest $request,
         ConfigurationService $configurationService,
-        \SimpleSAML_Configuration $oidcConfiguration
+        Configuration $oidcConfiguration
     ) {
         $configurationService->getOpenIDConnectConfiguration()->shouldBeCalled()->willReturn($oidcConfiguration);
         $configurationService->getOpenIDScopes()->shouldBeCalled()->willReturn(['openid' => 'openid']);

--- a/spec/Controller/OpenIdConnectInstallerControllerSpec.php
+++ b/spec/Controller/OpenIdConnectInstallerControllerSpec.php
@@ -20,6 +20,7 @@ use SimpleSAML\Modules\OpenIDConnect\Factories\TemplateFactory;
 use SimpleSAML\Modules\OpenIDConnect\Services\DatabaseLegacyOAuth2Import;
 use SimpleSAML\Modules\OpenIDConnect\Services\DatabaseMigration;
 use SimpleSAML\Modules\OpenIDConnect\Services\SessionMessagesService;
+use SimpleSAML\XHTML\Template;
 use Zend\Diactoros\Response\RedirectResponse;
 use Zend\Diactoros\ServerRequest;
 
@@ -58,7 +59,7 @@ class OpenIdConnectInstallerControllerSpec extends ObjectBehavior
     public function it_shows_information_page(
         ServerRequest $request,
         TemplateFactory $templateFactory,
-        \SimpleSAML_XHTML_Template $template
+        Template $template
     ) {
         $request->getParsedBody()->shouldBeCalled();
         $request->getMethod()->shouldBeCalled()->willReturn('GET');
@@ -74,7 +75,7 @@ class OpenIdConnectInstallerControllerSpec extends ObjectBehavior
         DatabaseMigration $databaseMigration,
         ServerRequest $request,
         TemplateFactory $templateFactory,
-        \SimpleSAML_XHTML_Template $template
+        Template $template
     ) {
         $request->getParsedBody()->shouldBeCalled();
         $request->getMethod()->shouldBeCalled()->willReturn('POST');

--- a/spec/Entity/ClientEntitySpec.php
+++ b/spec/Entity/ClientEntitySpec.php
@@ -32,7 +32,7 @@ class ClientEntitySpec extends ObjectBehavior
                 'name' => 'name',
                 'description' => 'description',
                 'auth_source' => 'auth_source',
-                'redirect_uri' => \json_encode(['https://localhost/redirect']),
+                'redirect_uri' => json_encode(['https://localhost/redirect']),
                 'scopes' => json_encode([]),
                 'is_enabled' => true,
             ],
@@ -98,7 +98,7 @@ class ClientEntitySpec extends ObjectBehavior
             'name' => 'name',
             'description' => 'description',
             'auth_source' => 'auth_source',
-            'redirect_uri' => \json_encode(['https://localhost/redirect']),
+            'redirect_uri' => json_encode(['https://localhost/redirect']),
             'scopes' => json_encode([]),
             'is_enabled' => true,
         ]);

--- a/spec/Services/AuthenticationServiceSpec.php
+++ b/spec/Services/AuthenticationServiceSpec.php
@@ -17,6 +17,7 @@ namespace spec\SimpleSAML\Modules\OpenIDConnect\Services;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
 use SimpleSAML\Auth\Simple;
+use SimpleSAML\Error\Exception;
 use SimpleSAML\Modules\OpenIDConnect\Entity\UserEntity;
 use SimpleSAML\Modules\OpenIDConnect\Factories\AuthSimpleFactory;
 use SimpleSAML\Modules\OpenIDConnect\Repositories\UserRepository;
@@ -84,7 +85,7 @@ class AuthenticationServiceSpec extends ObjectBehavior
             'eduPersonTargetedId' => [self::USERNAME],
         ]);
 
-        $this->shouldThrow(\SimpleSAML_Error_Exception::class)->during('getAuthenticateUser', [self::AUTH_SOURCE]);
+        $this->shouldThrow(Exception::class)->during('getAuthenticateUser', [self::AUTH_SOURCE]);
     }
 
     public function getMatchers(): array

--- a/spec/Services/SessionMessagesServiceSpec.php
+++ b/spec/Services/SessionMessagesServiceSpec.php
@@ -17,10 +17,11 @@ namespace spec\SimpleSAML\Modules\OpenIDConnect\Services;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
 use SimpleSAML\Modules\OpenIDConnect\Services\SessionMessagesService;
+use SimpleSAML\Session;
 
 class SessionMessagesServiceSpec extends ObjectBehavior
 {
-    public function let(\SimpleSAML_Session $session)
+    public function let(Session $session)
     {
         $this->beConstructedWith($session);
     }
@@ -30,14 +31,14 @@ class SessionMessagesServiceSpec extends ObjectBehavior
         $this->shouldHaveType(SessionMessagesService::class);
     }
 
-    public function it_adds_message(\SimpleSAML_Session $session)
+    public function it_adds_message(Session $session)
     {
         $session->setData('message', Argument::any(), 'value')->shouldBeCalled();
 
         $this->addMessage('value');
     }
 
-    public function it_gets_messages(\SimpleSAML_Session $session)
+    public function it_gets_messages(Session $session)
     {
         $session->getDataOfType('message')->shouldBeCalled()->willReturn([
             'msg1' => 'Message one.',

--- a/templates/oidc_base.twig
+++ b/templates/oidc_base.twig
@@ -1,42 +1,123 @@
-{% extends "base.twig" %}
+{%- set moduleurlpath = '/' ~  baseurlpath ~ 'module.php/oidc' -%}
+<!DOCTYPE html>
+<html lang="en">
 
-{% set moduleurlpath = '/' ~  baseurlpath ~ 'module.php/oidc' %}
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta http-equiv="X-UA-Compatible" content="ie=edge">
+    <meta name="robots" content="noindex, nofollow">
 
-{% block preload %}
+    <title>{{ pagetitle }}</title>
+
+
     <link rel="stylesheet" href="{{ moduleurlpath }}/resources/semantic/semantic.min.css">
+    <link rel="icon" href="/{{ baseurlpath }}resources/icons/favicon.ico">
     <style>
+        .content,
         body {
             padding: 10px 0;
             background: #1c1c1c;
             color: #333;
-            font-family: arial,tahoma,verdana,sans-serif;
+            font-family: arial, tahoma, verdana, sans-serif;
         }
-        #wrap h1 {
-            margin-top: 0;
+
+        body>.container>.segments {
+            border: 1px solid white;
+            border-radius: 0;
+        }
+
+        .ui.red.segment:not(.inverted) {
+            border-top: 6px solid #db2828 !important;
         }
     </style>
-{% endblock %}
-
-{% block contentwrapper %}
-    {% if messages is not empty %}
-        <div class="ui positive message">
-            {% for message in messages %}
-            <p>{% trans message %}</p>
-            {% endfor %}
-        </div>
+    {% if isRTL %}
+    <link rel="stylesheet" href="{{ asset("assets/css/src/default-rtl.css") }}">
     {% endif %}
-    {% block content %}{% endblock %}
+
+    {% block preload %}{% endblock %}
+</head>
+
+<body id="{{ templateId }}">
+    <div class="ui main container">
+        <div class="ui stacked segments">
+            <div class="ui inverted padded segment">
+                <div class="ui inverted header">
+                    {% if header == 'SimpleSAMLphp' %}
+                    <span class="simple">Simple</span>{# -#}
+                    <span class="saml">SAML</span>{# -#}
+                    <span class="simple">php</span>
+                    {% else %}
+                    {{ header }}
+                    {% endif %}
+                </div>
+            </div>
+            <div class="ui red segment">
+                <div class="ui breadcrumb">
+                    <a href="/{{ baseurlpath }}" class="section">
+                        SimpleSAMLphp
+                    </a>
+                    <span class="divider">/</span>
+                    <div class="active section">{{ pagetitle }}</div>
+                </div>
+
+                {% if not hideLanguageBar %}
+                <div class="ui floating dropdown labeled search icon button" style="float: right;"
+                    id="language-selector">
+                    <i class="world icon"></i>
+                    <span class="text">Select Language</span>
+                    <div class="menu">
+                        {% for key, lang in languageBar %}
+                        <div data-value="{{ key }}" class="item">{{ lang.name }}</div>
+                        {% endfor %}
+                    </div>
+                </div>
+                {% endif %}
+
+
+
+                {% block contentwrapper %}
+
+                {% if messages is not empty %}
+                <div class="ui positive message">
+                    {% for message in messages %}
+                    <p>{% trans message %}</p>
+                    {% endfor %}
+                </div>
+                {% endif %}
+
+                {% block content %}{% endblock %}
+
+                {% endblock %}
+            </div>
+            <div class="ui segment">
+                {% block footer %}{% include "_footer.twig" %}{% endblock %}
+            </div>
+        </div>
+    </div>
+</body>
+{% block postload %}
+<script type="text/javascript" src="{{ moduleurlpath }}/resources/jquery/jquery-3.3.1.min.js"></script>
+<script type="text/javascript" src="{{ moduleurlpath }}/resources/semantic/semantic.min.js"></script>
+<script>
+    $(document).ready(function () {
+        $('.ui.dropdown').dropdown();
+        $('#language-selector')
+            .dropdown('set selected', '{{ currentLanguage }}')
+            .dropdown({
+                onChange: function (value, text) {
+                    var url = new URL(window.location.href);
+                    url.searchParams.set('language', value);
+                    window.location.replace(url.href);
+                }
+            })
+            ;
+        $('.ui.checkbox').
+            checkbox();
+    });
+
+
+</script>
 {% endblock %}
 
-{% block postload %}
-    <script type="text/javascript" src="{{ moduleurlpath }}/resources/jquery/jquery-3.3.1.min.js"></script>
-    <script type="text/javascript" src="{{ moduleurlpath }}/resources/semantic/semantic.min.js"></script>
-    <script>
-        $('.ui.dropdown')
-            .dropdown()
-        ;
-        $('.ui.checkbox').
-            checkbox()
-        ;
-    </script>
-{% endblock %}
+</html>

--- a/tests/Repositories/AccessTokenRepositoryTest.php
+++ b/tests/Repositories/AccessTokenRepositoryTest.php
@@ -15,6 +15,7 @@
 namespace Tests\SimpleSAML\Modules\OpenIDConnect\Repositories;
 
 use PHPUnit\Framework\TestCase;
+use SimpleSAML\Configuration;
 use SimpleSAML\Modules\OpenIDConnect\Entity\ScopeEntity;
 use SimpleSAML\Modules\OpenIDConnect\Entity\UserEntity;
 use SimpleSAML\Modules\OpenIDConnect\Repositories\AccessTokenRepository;
@@ -45,7 +46,7 @@ class AccessTokenRepositoryTest extends TestCase
             'database.slaves' => [],
         ];
 
-        \SimpleSAML_Configuration::loadFromArray($config, '', 'simplesaml');
+        Configuration::loadFromArray($config, '', 'simplesaml');
         (new DatabaseMigration())->migrate();
 
         $client = ClientRepositoryTest::getClient(self::CLIENT_ID);

--- a/tests/Repositories/AuthCodeRepositoryTest.php
+++ b/tests/Repositories/AuthCodeRepositoryTest.php
@@ -15,6 +15,7 @@
 namespace Tests\SimpleSAML\Modules\OpenIDConnect\Repositories;
 
 use PHPUnit\Framework\TestCase;
+use SimpleSAML\Configuration;
 use SimpleSAML\Modules\OpenIDConnect\Entity\ScopeEntity;
 use SimpleSAML\Modules\OpenIDConnect\Entity\UserEntity;
 use SimpleSAML\Modules\OpenIDConnect\Repositories\AuthCodeRepository;
@@ -46,7 +47,7 @@ class AuthCodeRepositoryTest extends TestCase
             'database.slaves' => [],
         ];
 
-        \SimpleSAML_Configuration::loadFromArray($config, '', 'simplesaml');
+        Configuration::loadFromArray($config, '', 'simplesaml');
         (new DatabaseMigration())->migrate();
 
         $client = ClientRepositoryTest::getClient(self::CLIENT_ID);

--- a/tests/Repositories/ClientRepositoryTest.php
+++ b/tests/Repositories/ClientRepositoryTest.php
@@ -15,6 +15,7 @@
 namespace Tests\SimpleSAML\Modules\OpenIDConnect\Repositories;
 
 use PHPUnit\Framework\TestCase;
+use SimpleSAML\Configuration;
 use SimpleSAML\Modules\OpenIDConnect\Entity\ClientEntity;
 use SimpleSAML\Modules\OpenIDConnect\Repositories\ClientRepository;
 use SimpleSAML\Modules\OpenIDConnect\Services\DatabaseMigration;
@@ -37,7 +38,7 @@ class ClientRepositoryTest extends TestCase
             'database.slaves' => [],
         ];
 
-        \SimpleSAML_Configuration::loadFromArray($config, '', 'simplesaml');
+        Configuration::loadFromArray($config, '', 'simplesaml');
         (new DatabaseMigration())->migrate();
 
         self::$repository = new ClientRepository();

--- a/tests/Repositories/RefreshTokenRepositoryTest.php
+++ b/tests/Repositories/RefreshTokenRepositoryTest.php
@@ -15,6 +15,7 @@
 namespace Tests\SimpleSAML\Modules\OpenIDConnect\Repositories;
 
 use PHPUnit\Framework\TestCase;
+use SimpleSAML\Configuration;
 use SimpleSAML\Modules\OpenIDConnect\Entity\AccessTokenEntity;
 use SimpleSAML\Modules\OpenIDConnect\Entity\UserEntity;
 use SimpleSAML\Modules\OpenIDConnect\Repositories\AccessTokenRepository;
@@ -47,7 +48,7 @@ class RefreshTokenRepositoryTest extends TestCase
             'database.slaves' => [],
         ];
 
-        \SimpleSAML_Configuration::loadFromArray($config, '', 'simplesaml');
+        Configuration::loadFromArray($config, '', 'simplesaml');
         (new DatabaseMigration())->migrate();
 
         $client = ClientRepositoryTest::getClient(self::CLIENT_ID);

--- a/tests/Repositories/ScopeRepositoryTest.php
+++ b/tests/Repositories/ScopeRepositoryTest.php
@@ -15,6 +15,7 @@
 namespace Tests\SimpleSAML\Modules\OpenIDConnect\Repositories;
 
 use PHPUnit\Framework\TestCase;
+use SimpleSAML\Configuration;
 use SimpleSAML\Modules\OpenIDConnect\Entity\ScopeEntity;
 use SimpleSAML\Modules\OpenIDConnect\Repositories\ScopeRepository;
 use SimpleSAML\Modules\OpenIDConnect\Services\ConfigurationService;
@@ -33,8 +34,8 @@ class ScopeRepositoryTest extends TestCase
             'database.slaves' => [],
         ];
 
-        \SimpleSAML_Configuration::loadFromArray($config, '', 'simplesaml');
-        \SimpleSAML_Configuration::setConfigDir(__DIR__.'/../../config-template');
+        Configuration::loadFromArray($config, '', 'simplesaml');
+        Configuration::setConfigDir(__DIR__.'/../../config-template');
         (new DatabaseMigration())->migrate();
     }
 

--- a/tests/Repositories/UserRepositoryTest.php
+++ b/tests/Repositories/UserRepositoryTest.php
@@ -15,6 +15,7 @@
 namespace Tests\SimpleSAML\Modules\OpenIDConnect\Repositories;
 
 use PHPUnit\Framework\TestCase;
+use SimpleSAML\Configuration;
 use SimpleSAML\Modules\OpenIDConnect\Entity\UserEntity;
 use SimpleSAML\Modules\OpenIDConnect\Repositories\UserRepository;
 use SimpleSAML\Modules\OpenIDConnect\Services\DatabaseMigration;
@@ -32,7 +33,7 @@ class UserRepositoryTest extends TestCase
             'database.slaves' => [],
         ];
 
-        \SimpleSAML_Configuration::loadFromArray($config, '', 'simplesaml');
+        Configuration::loadFromArray($config, '', 'simplesaml');
         (new DatabaseMigration())->migrate();
     }
 

--- a/tests/Services/JsonWebKeySetServiceTest.php
+++ b/tests/Services/JsonWebKeySetServiceTest.php
@@ -17,6 +17,8 @@ namespace Tests\SimpleSAML\Modules\OpenIDConnect\Services;
 use Jose\Factory\JWKFactory;
 use Jose\Object\JWKSet;
 use PHPUnit\Framework\TestCase;
+use SimpleSAML\Configuration;
+use SimpleSAML\Error\Exception;
 use SimpleSAML\Modules\OpenIDConnect\Services\JsonWebKeySetService;
 
 class JsonWebKeySetServiceTest extends TestCase
@@ -57,7 +59,7 @@ class JsonWebKeySetServiceTest extends TestCase
         $config = [
             'certdir' => sys_get_temp_dir(),
         ];
-        \SimpleSAML_Configuration::loadFromArray($config, '', 'simplesaml');
+        Configuration::loadFromArray($config, '', 'simplesaml');
 
         $jwk = JWKFactory::createFromKey(self::$pkGeneratePublic, null, [
             'kid' => 'oidc',
@@ -73,14 +75,14 @@ class JsonWebKeySetServiceTest extends TestCase
     }
 
     /**
-     * @expectedException \SimpleSAML_Error_Error
+     * @expectedException Exception
      */
     public function testCertificationFileNotFound()
     {
         $config = [
             'certdir' => __DIR__,
         ];
-        \SimpleSAML_Configuration::loadFromArray($config, '', 'simplesaml');
+        Configuration::loadFromArray($config, '', 'simplesaml');
 
         new JsonWebKeySetService();
     }


### PR DESCRIPTION
Updates to maintain compatibility with SSP 1.18.

Some BC:

- The config option `usenewui` must be **disabled** from this PR. It will be enabled automatically.

New requirements:

All paths are changed from old style `SimpleSAML_*` to the new PSR namespaces `SimpleSAML\*`. For that reason, this module is not compatible with old version.