### PR TITLE
Fix JWKS endpoint to comply with RFC 7517

### DIFF
--- a/lib/Controller/OpenIdConnectJwksController.php
+++ b/lib/Controller/OpenIdConnectJwksController.php
@@ -33,7 +33,7 @@ class OpenIdConnectJwksController
     public function __invoke(ServerRequest $request): JsonResponse
     {
         return new JsonResponse([
-            'keys' => $this->jsonWebKeySetService->keys(),
+            'keys' => array_values($this->jsonWebKeySetService->keys()),
         ]);
     }
 }


### PR DESCRIPTION
According to https://tools.ietf.org/html/rfc7517#section-5.1 the
'keys' parameter is an array but an object was being returned.

Related with #36

Thanks @andres-blanco