### PR TITLE
Add support for array values in user info

### DIFF
--- a/lib/ClaimTranslatorExtractor.php
+++ b/lib/ClaimTranslatorExtractor.php
@@ -114,7 +114,8 @@ class ClaimTranslatorExtractor extends ClaimExtractor
         foreach ($this->translationTable as $claim => $samlMatches) {
             foreach ($samlMatches as $samlMatch) {
                 if (\array_key_exists($samlMatch, $samlAttributes)) {
-                    $claims[$claim] = current($samlAttributes[$samlMatch]);
+                    if (sizeof($samlAttributes[$samlMatch]) > 1) $claims[$claim] = $samlAttributes[$samlMatch];
+                    else $claims[$claim] = current($samlAttributes[$samlMatch]);
                     break;
                 }
             }


### PR DESCRIPTION
This is useful for example for `memberOf` where a user may be a member of multiple groups. Otherwise, calling `current()` will just return the first one. If `current()` is not needed at all we can just make it set the claim value directly.

This is for supporting https://github.com/Place1/wg-access-server. We should also maybe add support for telling the custom claims to be an array all the time.