### PR TITLE
Feature/authproc

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,46 @@ $config = [
 ];
 ```
 
+#### Auth Proc Filters
+This module will not execute standard Auth Proc Filters which are used during regular SAML authN, reason being that 
+not all expected entities are participating in the authN process (most notably the Service Provider - SP). 
+Because of that, OIDC module provides its own 'authproc.oidc' configuration option which can be used to designate 
+specific Auth Proc Filters which will run only during OIDC authN. 
+
+However, there are some considerations. OIDC authN state array will not contain all the keys which are 
+available during SAML authN, like Service Provider metadata. If you are using an existing filter, make sure it does 
+not rely on some non-existent state data. At the moment, only the following SAML authN data will be available:
+* 'Attributes'
+* 'Authority'
+* 'AuthnInstant'
+* 'Expire'
+* 'IdPMetadata'
+* 'Source'
+
+In addition to that, the following OIDC related data will be available in the state array:
+* 'OidcProviderMetadata' - contains information otherwise available from the OIDC configuration URL.
+* 'OidcRelyingPartyMetadata' - contains information about the OIDC client making the authN request.
+* 'OidcAuthorizationRequestParameters' - contains relevant authorization request query parameters.
+
+Note: at the moment there is no support for showing a page to the user in a filter, and then resuming the filtering.
+Only the common filter use cases are supported like attribute handling, logging, or similar. 
+
+You can add Auth Proc filters in the 'authproc.oidc' config option in the same manner as described in the [Auth Proc 
+documentation](https://simplesamlphp.org/docs/stable/simplesamlphp-authproc).
+
+```php
+<?php
+
+$config = [
+    'authproc.oidc' => [
+        50 => [
+            'class' => 'core:AttributeAdd',
+            'groups' => ['users', 'members'],
+        ],
+    ],
+];
+```
+
 #### Cron hook
 
 This module requires [cron module](https://simplesamlphp.org/docs/stable/cron:cron) is active to remove old tokens.

--- a/config-templates/module_oidc.php
+++ b/config-templates/module_oidc.php
@@ -37,6 +37,23 @@ $config = [
     // useridattr is the attribute-name that contains the userid as returned from idp
     'useridattr' => 'uid',
 
+    // Settings regarding Authentication Processing Filters.
+    // Note: OIDC authN state array will not contain all of the keys which are available during SAML authN,
+    // like Service Provider metadata, etc.
+    //
+    // At the moment, the following SAML authN data will be available during OIDC authN in the sate array:
+    // - 'Attributes', 'Authority', 'AuthnInstant', 'Expire', 'IdPMetadata', 'Source'
+    // In addition to that, the following OIDC related data will be available in the state array:
+    // - 'OidcProviderMetadata' - contains information otherwise available from the OIDC configuration URL.
+    // - 'OidcRelyingPartyMetadata' - contains information about the OIDC client making the authN request.
+    // - 'OidcAuthorizationRequestParameters' - contains relevant authorization request query parameters.
+    //
+    // List of authproc filters which will run for every OIDC authN. Add filters as described in docs for SAML authproc
+    // @see https://simplesamlphp.org/docs/stable/simplesamlphp-authproc
+    'authproc.oidc' => [
+        // Add authproc filters here
+    ],
+
     // You can create as many scopes as you want and assign attributes to them
     'scopes' => [
         /*

--- a/lib/ClaimTranslatorExtractor.php
+++ b/lib/ClaimTranslatorExtractor.php
@@ -104,8 +104,11 @@ class ClaimTranslatorExtractor extends ClaimExtractor
      * @param array $allowedMultipleValueClaims
      * @throws \OpenIDConnectServer\Exception\InvalidArgumentException
      */
-    public function __construct(array $claimSets = [], array $translationTable = [], array $allowedMultipleValueClaims = [])
-    {
+    public function __construct(
+        array $claimSets = [],
+        array $translationTable = [],
+        array $allowedMultipleValueClaims = []
+    ) {
         $this->translationTable = array_merge($this->translationTable, $translationTable);
 
         $this->allowedMultiValueClaims = $allowedMultipleValueClaims;

--- a/lib/Controller/OpenIdConnectDiscoverConfigurationController.php
+++ b/lib/Controller/OpenIdConnectDiscoverConfigurationController.php
@@ -14,39 +14,25 @@
 
 namespace SimpleSAML\Modules\OpenIDConnect\Controller;
 
-use SimpleSAML\Modules\OpenIDConnect\Services\ConfigurationService;
 use Laminas\Diactoros\Response\JsonResponse;
 use Laminas\Diactoros\ServerRequest;
+use SimpleSAML\Modules\OpenIDConnect\Services\OidcProviderMetadataService;
 
 class OpenIdConnectDiscoverConfigurationController
 {
     /**
-     * @var ConfigurationService
+     * @var OidcProviderMetadataService
      */
-    private $configurationService;
+    private $oidcProviderMetadataService;
 
     public function __construct(
-        ConfigurationService $configurationService
+        OidcProviderMetadataService $oidcProviderMetadataService
     ) {
-        $this->configurationService = $configurationService;
+        $this->oidcProviderMetadataService = $oidcProviderMetadataService;
     }
 
     public function __invoke(ServerRequest $serverRequest): JsonResponse
     {
-        $scopes = $this->configurationService->getOpenIDScopes();
-
-        $metadata = [];
-        $metadata['issuer'] = $this->configurationService->getSimpleSAMLSelfURLHost();
-        $metadata['authorization_endpoint'] = $this->configurationService->getOpenIdConnectModuleURL('authorize.php');
-        $metadata['token_endpoint'] = $this->configurationService->getOpenIdConnectModuleURL('access_token.php');
-        $metadata['userinfo_endpoint'] = $this->configurationService->getOpenIdConnectModuleURL('userinfo.php');
-        $metadata['jwks_uri'] = $this->configurationService->getOpenIdConnectModuleURL('jwks.php');
-        $metadata['scopes_supported'] = array_keys($scopes);
-        $metadata['response_types_supported'] = ['code', 'token'];
-        $metadata['subject_types_supported'] = ['public'];
-        $metadata['id_token_signing_alg_values_supported'] = ['RS256'];
-        $metadata['code_challenge_methods_supported'] = ['plain', 'S256'];
-
-        return new JsonResponse($metadata);
+        return new JsonResponse($this->oidcProviderMetadataService->getMetadata());
     }
 }

--- a/lib/Services/AuthProcService.php
+++ b/lib/Services/AuthProcService.php
@@ -1,0 +1,112 @@
+<?php
+
+namespace SimpleSAML\Modules\OpenIDConnect\Services;
+
+use SimpleSAML\Auth\ProcessingFilter;
+use SimpleSAML\Module;
+
+class AuthProcService
+{
+    /**
+     * @var ConfigurationService
+     */
+    private $configurationService;
+
+    /**
+     * @var array Filters to be applied to OIDC state.
+     */
+    private $filters = [];
+
+    /**
+     * AuthProcService constructor.
+     * @param ConfigurationService $configurationService
+     *
+     * @throws \Exception
+     * @see \SimpleSAML\Auth\ProcessingChain for original implementation
+     */
+    public function __construct(
+        ConfigurationService $configurationService
+    ) {
+        $this->configurationService = $configurationService;
+        $this->loadFilters();
+    }
+
+    /**
+     * Load filters defined in configuration.
+     * @throws \Exception
+     */
+    private function loadFilters(): void
+    {
+        $oidcAuthProcFilters = $this->configurationService->getAuthProcFilters();
+        $this->filters = $this->parseFilterList($oidcAuthProcFilters);
+    }
+
+    /**
+     * Parse an array of authentication processing filters.
+     * @see \SimpleSAML\Auth\ProcessingChain::parseFilterList for original implementation
+     *
+     * @param array $filterSrc Array with filter configuration.
+     * @return array  Array of ProcessingFilter objects.
+     * @throws \Exception
+     */
+    private function parseFilterList(array $filterSrc): array
+    {
+        $parsedFilters = [];
+
+        foreach ($filterSrc as $priority => $filterConfig) {
+            if (is_string($filterConfig)) {
+                $filterConfig = ['class' => $filterConfig];
+            }
+
+            if (!is_array($filterConfig)) {
+                throw new \Exception('Invalid authentication processing filter configuration: ' .
+                                     'One of the filters wasn\'t a string or an array.');
+            }
+
+            if (!array_key_exists('class', $filterConfig)) {
+                throw new \Exception('Authentication processing filter without name given.');
+            }
+
+            $className = Module::resolveClass(
+                $filterConfig['class'],
+                'Auth\Process',
+                '\SimpleSAML\Auth\ProcessingFilter'
+            );
+
+            $filterConfig['%priority'] = $priority;
+            unset($filterConfig['class']);
+
+            /**
+             * @psalm-suppress InvalidStringClass
+             */
+            $parsedFilters[] = new $className($filterConfig, null);
+        }
+
+        return $parsedFilters;
+    }
+
+    /**
+     * Process given state array.
+     *
+     * @param array $state
+     * @return array
+     */
+    public function processState(array $state): array
+    {
+        foreach ($this->filters as $filter) {
+            $filter->process($state);
+        }
+
+        return $state;
+    }
+
+    /**
+     * Get filters loaded from configuration.
+     *
+     * @return array
+     */
+    public function getLoadedFilters(): array
+    {
+        return $this->filters;
+    }
+}

--- a/lib/Services/AuthenticationService.php
+++ b/lib/Services/AuthenticationService.php
@@ -14,13 +14,25 @@
 
 namespace SimpleSAML\Modules\OpenIDConnect\Services;
 
+use Laminas\Diactoros\ServerRequest;
+use SimpleSAML\Auth\Simple;
 use SimpleSAML\Error\Exception;
+use SimpleSAML\Modules\OpenIDConnect\Controller\Traits\GetClientFromRequestTrait;
+use SimpleSAML\Modules\OpenIDConnect\Entity\ClientEntity;
 use SimpleSAML\Modules\OpenIDConnect\Entity\UserEntity;
 use SimpleSAML\Modules\OpenIDConnect\Factories\AuthSimpleFactory;
+use SimpleSAML\Modules\OpenIDConnect\Repositories\ClientRepository;
 use SimpleSAML\Modules\OpenIDConnect\Repositories\UserRepository;
 
 class AuthenticationService
 {
+    use GetClientFromRequestTrait;
+
+    /**
+     * @var ConfigurationService
+     */
+    private $configurationService;
+
     /**
      * @var UserRepository
      */
@@ -34,25 +46,58 @@ class AuthenticationService
      */
     private $userIdAttr;
 
+    /**
+     * @var AuthProcService
+     */
+    private $authProcService;
+
+    /**
+     * @var OidcProviderMetadataService
+     */
+    private $oidcProviderMetadataService;
+
+    /**
+     * @var IdProviderMetadataService
+     */
+    private $idProviderMetadataService;
+
     public function __construct(
+        ConfigurationService $configurationService,
         UserRepository $userRepository,
         AuthSimpleFactory $authSimpleFactory,
+        AuthProcService $authProcService,
+        ClientRepository $clientRepository,
+        OidcProviderMetadataService $oidcProviderMetadataService,
+        IdProviderMetadataService $idProviderMetadataService,
         string $userIdAttr
     ) {
+        $this->configurationService = $configurationService;
         $this->userRepository = $userRepository;
         $this->authSimpleFactory = $authSimpleFactory;
+        $this->authProcService = $authProcService;
+        $this->clientRepository = $clientRepository;
+        $this->oidcProviderMetadataService = $oidcProviderMetadataService;
+        $this->idProviderMetadataService = $idProviderMetadataService;
         $this->userIdAttr = $userIdAttr;
     }
 
     /**
-     * @throws Exception
+     * @param ServerRequest $request
+     * @return UserEntity
+     * @throws \Exception
      */
-    public function getAuthenticateUser(string $authSource): UserEntity
+    public function getAuthenticateUser(ServerRequest $request): UserEntity
     {
+        $oidcClient = $this->getClientFromRequest($request);
+        $authSource = $this->resolveAuthSource($oidcClient);
+
         $authSimple = $this->authSimpleFactory->build($authSource);
         $authSimple->requireAuth();
 
-        $claims = $authSimple->getAttributes();
+        $state = $this->prepareStateArray($authSimple, $oidcClient, $request);
+        $state = $this->authProcService->processState($state);
+        $claims = $state['Attributes'];
+
         if (!\array_key_exists($this->userIdAttr, $claims)) {
             $attr = implode(', ', array_keys($claims));
             throw new Exception('Attribute `useridattr` doesn\'t exists in claims. Available attributes are: ' . $attr);
@@ -70,5 +115,44 @@ class AuthenticationService
         }
 
         return $user;
+    }
+
+    /**
+     * Get auth source defined on the client. If not set on the client, get the default auth source defined in config.
+     *
+     * @param ClientEntity $client
+     * @return string
+     * @throws \Exception
+     */
+    private function resolveAuthSource(ClientEntity $client): string
+    {
+        return $client->getAuthSource() ??
+            $this->configurationService->getOpenIDConnectConfiguration()->getString('auth');
+    }
+
+    /**
+     * @param Simple $authSimple
+     * @param ClientEntity $client
+     * @param ServerRequest $request
+     * @return array
+     */
+    private function prepareStateArray(Simple $authSimple, ClientEntity $client, ServerRequest $request): array
+    {
+        $state = $authSimple->getAuthDataArray();
+
+        $state['OidcProviderMetadata'] = $this->oidcProviderMetadataService->getMetadata();
+
+        $state['OidcRelyingPartyMetadata'] = array_filter($client->toArray(), function (string $key) {
+            return $key !== 'secret';
+        }, ARRAY_FILTER_USE_KEY);
+
+        $state['OidcAuthorizationRequestParameters'] = array_filter($request->getQueryParams(), function (string $key) {
+            $relevantAuthzParams = ['response_type', 'client_id', 'redirect_uri', 'scope', 'code_challenge_method'];
+            return in_array($key, $relevantAuthzParams);
+        }, ARRAY_FILTER_USE_KEY);
+
+        $state['Source'] = $state['IdPMetadata'] = $this->idProviderMetadataService->getMetadata();
+
+        return $state;
     }
 }

--- a/lib/Services/ConfigurationService.php
+++ b/lib/Services/ConfigurationService.php
@@ -135,4 +135,15 @@ class ConfigurationService
 
         return $signer;
     }
+
+    /**
+     * Get autproc filters defined in the OIDC configuration.
+     *
+     * @return array
+     * @throws \Exception
+     */
+    public function getAuthProcFilters(): array
+    {
+        return $this->getOpenIDConnectConfiguration()->getArray('authproc.oidc', []);
+    }
 }

--- a/lib/Services/Container.php
+++ b/lib/Services/Container.php
@@ -24,6 +24,7 @@ use Psr\Container\NotFoundExceptionInterface;
 use SimpleSAML\Configuration;
 use SimpleSAML\Database;
 use SimpleSAML\Error\Exception;
+use SimpleSAML\Metadata\MetaDataStorageHandler;
 use SimpleSAML\Modules\OpenIDConnect\ClaimTranslatorExtractor;
 use SimpleSAML\Modules\OpenIDConnect\Factories\AuthorizationServerFactory;
 use SimpleSAML\Modules\OpenIDConnect\Factories\AuthSimpleFactory;
@@ -98,9 +99,26 @@ class Container implements ContainerInterface
         $templateFactory = new TemplateFactory($simpleSAMLConfiguration);
         $this->services[TemplateFactory::class] = $templateFactory;
 
+        $authProcService = new AuthProcService($configurationService);
+        $this->services[AuthProcService::class] = $authProcService;
+
+        $oidcProviderMetadataService = new OidcProviderMetadataService($configurationService);
+        $this->services[OidcProviderMetadataService::class] = $oidcProviderMetadataService;
+
+        $metadataStorageHandler = MetaDataStorageHandler::getMetadataHandler();
+        $this->services[MetaDataStorageHandler::class] = $metadataStorageHandler;
+
+        $idProviderMetadataService = new IdProviderMetadataService($metadataStorageHandler);
+        $this->services[IdProviderMetadataService::class] = $idProviderMetadataService;
+
         $authenticationService = new AuthenticationService(
+            $configurationService,
             $userRepository,
             $authSimpleFactory,
+            $authProcService,
+            $clientRepository,
+            $oidcProviderMetadataService,
+            $idProviderMetadataService,
             $oidcModuleConfiguration->getString('useridattr', 'uid')
         );
         $this->services[AuthenticationService::class] = $authenticationService;

--- a/lib/Services/IdProviderMetadataService.php
+++ b/lib/Services/IdProviderMetadataService.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace SimpleSAML\Modules\OpenIDConnect\Services;
+
+use SimpleSAML\Metadata\MetaDataStorageHandler;
+
+/**
+ * Serves SAML IdP Metadata.
+ *
+ * Class IdProviderMetadataService
+ * @package SimpleSAML\Modules\OpenIDConnect\Services
+ */
+class IdProviderMetadataService
+{
+    /**
+     * @var MetaDataStorageHandler $metaDataStorageHandler
+     */
+    private $metaDataStorageHandler;
+
+    public function __construct(MetaDataStorageHandler $metaDataStorageHandler)
+    {
+        $this->metaDataStorageHandler = $metaDataStorageHandler;
+    }
+
+    /**
+     * Get current IdP metadata.
+     *
+     * @return array
+     */
+    public function getMetadata(): array
+    {
+        return $this->metaDataStorageHandler->getMetaDataCurrent('saml20-idp-hosted');
+    }
+}

--- a/lib/Services/OidcProviderMetadataService.php
+++ b/lib/Services/OidcProviderMetadataService.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace SimpleSAML\Modules\OpenIDConnect\Services;
+
+/**
+ * OpenID Connect (OIDC) Provider Metadata Service - provides information about OIDC authentication server.
+ *
+ * Class OPMetadataService
+ * @package SimpleSAML\Modules\OpenIDConnect\Services
+ */
+class OidcProviderMetadataService
+{
+    /**
+     * @var ConfigurationService
+     */
+    private $configurationService;
+
+    /**
+     * @var array $metadata
+     */
+    private $metadata;
+
+    public function __construct(
+        ConfigurationService $configurationService
+    ) {
+        $this->configurationService = $configurationService;
+        $this->initMetadata();
+    }
+
+    /**
+     * Initialize metadata array.
+     */
+    public function initMetadata(): void
+    {
+        $this->metadata = [];
+        $this->metadata['issuer'] = $this->configurationService->getSimpleSAMLSelfURLHost();
+        $this->metadata['authorization_endpoint'] =
+            $this->configurationService->getOpenIdConnectModuleURL('authorize.php');
+        $this->metadata['token_endpoint'] = $this->configurationService->getOpenIdConnectModuleURL('access_token.php');
+        $this->metadata['userinfo_endpoint'] = $this->configurationService->getOpenIdConnectModuleURL('userinfo.php');
+        $this->metadata['jwks_uri'] = $this->configurationService->getOpenIdConnectModuleURL('jwks.php');
+        $this->metadata['scopes_supported'] = array_keys($this->configurationService->getOpenIDScopes());
+        $this->metadata['response_types_supported'] = ['code', 'token'];
+        $this->metadata['subject_types_supported'] = ['public'];
+        $this->metadata['id_token_signing_alg_values_supported'] = ['RS256'];
+        $this->metadata['code_challenge_methods_supported'] = ['plain', 'S256'];
+    }
+
+    /**
+     * Get OIDC Provider (OP) metadata array.
+     *
+     * @return array
+     */
+    public function getMetadata(): array
+    {
+        return $this->metadata;
+    }
+}

--- a/spec/Services/AuthProcServiceSpec.php
+++ b/spec/Services/AuthProcServiceSpec.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace spec\SimpleSAML\Modules\OpenIDConnect\Services;
+
+use PhpSpec\ObjectBehavior;
+use SimpleSAML\Modules\OpenIDConnect\Services\AuthProcService;
+use SimpleSAML\Modules\OpenIDConnect\Services\ConfigurationService;
+
+class AuthProcServiceSpec extends ObjectBehavior
+{
+    public function let(
+        ConfigurationService $configurationService
+    ): void {
+        $configurationService->getAuthProcFilters()->willReturn([]);
+        $this->beConstructedWith($configurationService);
+    }
+
+    public function it_is_initializable(): void
+    {
+        $this->shouldHaveType(AuthProcService::class);
+    }
+
+    public function it_loads_configured_filters(
+        ConfigurationService $configurationService
+    ): void {
+        $configurationService->getAuthProcFilters()->willReturn(['\SimpleSAML\Module\core\Auth\Process\AttributeAdd',]);
+        $this->getLoadedFilters()->shouldBeArray();
+        $this->getLoadedFilters()->shouldHaveCount(1);
+    }
+
+    public function it_executes_configured_filters(
+        ConfigurationService $configurationService
+    ): void {
+        $sampleFilters = [
+            50 => [
+                'class' => '\SimpleSAML\Module\core\Auth\Process\AttributeAdd',
+                'newKey' => ['newValue']
+            ],
+        ];
+
+        $configurationService->getAuthProcFilters()->willReturn($sampleFilters);
+
+        $state = ['Attributes' => ['existingKey' => ['existingValue']]];
+
+        $this->processState($state)->shouldHaveKeyWithValueCustom('newKey', 'newValue');
+        $this->processState($state)->shouldHaveKeyWithValueCustom('existingKey', 'existingValue');
+    }
+
+    public function getMatchers(): array
+    {
+        return [
+            'haveKeyWithValueCustom' => function ($subject, $key, $value) {
+                $attributes = $subject['Attributes'];
+                return array_key_exists($key, $attributes) &&
+                    ($value === $attributes[$key][0]);
+            },
+        ];
+    }
+}

--- a/spec/Services/AuthenticationServiceSpec.php
+++ b/spec/Services/AuthenticationServiceSpec.php
@@ -14,34 +14,90 @@
 
 namespace spec\SimpleSAML\Modules\OpenIDConnect\Services;
 
+use Laminas\Diactoros\ServerRequest;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
 use SimpleSAML\Auth\Simple;
 use SimpleSAML\Error\Exception;
+use SimpleSAML\Modules\OpenIDConnect\Entity\ClientEntity;
 use SimpleSAML\Modules\OpenIDConnect\Entity\UserEntity;
 use SimpleSAML\Modules\OpenIDConnect\Factories\AuthSimpleFactory;
+use SimpleSAML\Modules\OpenIDConnect\Repositories\ClientRepository;
 use SimpleSAML\Modules\OpenIDConnect\Repositories\UserRepository;
 use SimpleSAML\Modules\OpenIDConnect\Services\AuthenticationService;
+use SimpleSAML\Modules\OpenIDConnect\Services\AuthProcService;
+use SimpleSAML\Modules\OpenIDConnect\Services\ConfigurationService;
+use SimpleSAML\Modules\OpenIDConnect\Services\IdProviderMetadataService;
+use SimpleSAML\Modules\OpenIDConnect\Services\OidcProviderMetadataService;
 
 class AuthenticationServiceSpec extends ObjectBehavior
 {
     public const AUTH_SOURCE = 'auth_source';
     public const USER_ID_ATTR = 'uid';
     public const USERNAME = 'username';
+    public const OIDC_METADATA = ['issuer' => 'https://idp.example.org'];
+    public const IDP_METADATA = ['entityid' => 'https://idp.example.org'];
+    public const USER_ENTITY_ATTRIBUTES = [
+        self::USER_ID_ATTR => [self::USERNAME],
+        'eduPersonTargetedId' => [self::USERNAME],
+    ];
+    public const AUTH_DATA = ['Attributes' => self::USER_ENTITY_ATTRIBUTES];
+    public const CLIENT_ENTITY = ['id' => 'clientid', 'redirect_uri' => 'https://rp.example.org'];
+    public const STATE = [
+        'Attributes' => self::AUTH_DATA['Attributes'],
+        'OidcProviderMetadata' => self::OIDC_METADATA,
+        'OidcRelyingPartyMetadata' => self::CLIENT_ENTITY,
+        'IdPMetadata' => self::IDP_METADATA
+    ];
+    public const AUTHZ_REQUEST_PARAMS = ['client_id' => 'clientid', 'redirect_uri' => 'https://rp.example.org'];
 
     /**
+     * @param ServerRequest $request
+     * @param ClientEntity $clientEntity
+     * @param UserRepository $userRepository
+     * @param AuthSimpleFactory $authSimpleFactory
+     * @param Simple $simple
+     * @param AuthProcService $authProcService
+     * @param ClientRepository $clientRepository
+     * @param ConfigurationService $configurationService
+     * @param OidcProviderMetadataService $oidcProviderMetadataService
+     * @param IdProviderMetadataService $idProviderMetadataService
      * @return void
      */
     public function let(
+        ServerRequest $request,
+        ClientEntity $clientEntity,
         UserRepository $userRepository,
         AuthSimpleFactory $authSimpleFactory,
-        Simple $simple
-    ) {
-        $this->beConstructedWith($userRepository, $authSimpleFactory, self::USER_ID_ATTR);
+        Simple $simple,
+        AuthProcService $authProcService,
+        ClientRepository $clientRepository,
+        ConfigurationService $configurationService,
+        OidcProviderMetadataService $oidcProviderMetadataService,
+        IdProviderMetadataService $idProviderMetadataService
+    ): void {
+        $request->getQueryParams()->willReturn(self::AUTHZ_REQUEST_PARAMS);
+        $clientEntity->getAuthSource()->willReturn(self::AUTH_SOURCE);
+        $clientEntity->toArray()->willReturn(self::CLIENT_ENTITY);
+        $clientRepository->findById(self::CLIENT_ENTITY['id'])->willReturn($clientEntity);
+        $simple->getAttributes()->willReturn(self::AUTH_DATA['Attributes']);
+        $simple->getAuthDataArray()->willReturn(self::AUTH_DATA);
         $authSimpleFactory->build(self::AUTH_SOURCE)->willReturn($simple);
-        $simple->getAttributes()->willReturn([
-            self::USER_ID_ATTR => [self::USERNAME],
-        ]);
+        $oidcProviderMetadataService->getMetadata()->willReturn(self::OIDC_METADATA);
+        $idProviderMetadataService->getMetadata()->willReturn(self::IDP_METADATA);
+        $configurationService->getAuthProcFilters()->willReturn([]);
+        $authProcService->processState(Argument::type('array'))->willReturn(self::STATE);
+
+        $this->beConstructedWith(
+            $configurationService,
+            $userRepository,
+            $authSimpleFactory,
+            $authProcService,
+            $clientRepository,
+            $oidcProviderMetadataService,
+            $idProviderMetadataService,
+            self::USER_ID_ATTR
+        );
     }
 
     /**
@@ -53,54 +109,61 @@ class AuthenticationServiceSpec extends ObjectBehavior
     }
 
     /**
+     * @param ServerRequest $request
+     * @param Simple $simple
+     * @param UserRepository $userRepository
      * @return void
+     * @throws \Exception
      */
     public function it_creates_new_user(
+        ServerRequest $request,
         Simple $simple,
         UserRepository $userRepository
-    ) {
+    ): void {
         $simple->requireAuth()->shouldBeCalled();
-        $simple->getAttributes()->shouldBeCalled();
 
         $userRepository->getUserEntityByIdentifier(self::USERNAME)->shouldBeCalled()->willReturn(null);
         $userRepository->add(Argument::type(UserEntity::class))->shouldBeCalled();
 
-        $this->getAuthenticateUser(self::AUTH_SOURCE)->shouldHaveIdentifier(self::USERNAME);
-        $this->getAuthenticateUser(self::AUTH_SOURCE)->shouldHaveClaims([self::USER_ID_ATTR => [self::USERNAME]]);
+        $this->getAuthenticateUser($request)->shouldHaveIdentifier(self::USERNAME);
+        $this->getAuthenticateUser($request)->shouldHaveClaims(self::USER_ENTITY_ATTRIBUTES);
     }
 
     /**
+     * @param ServerRequest $request
+     * @param Simple $simple
+     * @param UserRepository $userRepository
+     * @param UserEntity $userEntity
      * @return void
+     * @throws \Exception
      */
     public function it_returns_an_user(
+        ServerRequest $request,
         Simple $simple,
         UserRepository $userRepository,
         UserEntity $userEntity
-    ) {
+    ): void {
         $simple->requireAuth()->shouldBeCalled();
-        $simple->getAttributes()->shouldBeCalled();
 
         $userRepository->getUserEntityByIdentifier(self::USERNAME)->shouldBeCalled()->willReturn($userEntity);
-        $userEntity->setClaims([
-            self::USER_ID_ATTR => [self::USERNAME],
-        ])->shouldBeCalled();
+        $userEntity->setClaims(self::USER_ENTITY_ATTRIBUTES)->shouldBeCalled();
         $userRepository->update($userEntity)->shouldBeCalled();
-
-        $this->getAuthenticateUser(self::AUTH_SOURCE)->shouldBe($userEntity);
+        $this->getAuthenticateUser($request)->shouldBe($userEntity);
     }
 
-    /**
-     * @return void
-     */
     public function it_throws_exception_if_claims_not_exists(
+        ServerRequest $request,
+        AuthProcService $authProcService,
         Simple $simple
-    ) {
+    ): void {
         $simple->requireAuth()->shouldBeCalled();
-        $simple->getAttributes()->shouldBeCalled()->willReturn([
-            'eduPersonTargetedId' => [self::USERNAME],
-        ]);
 
-        $this->shouldThrow(Exception::class)->during('getAuthenticateUser', [self::AUTH_SOURCE]);
+        $invalidState = self::STATE;
+        unset($invalidState['Attributes'][self::USER_ID_ATTR]);
+
+        $authProcService->processState(Argument::type('array'))->shouldBeCalled()->willReturn($invalidState);
+
+        $this->shouldThrow(Exception::class)->during('getAuthenticateUser', [$request]);
     }
 
     public function getMatchers(): array

--- a/spec/Services/IdProviderMetadataServiceSpec.php
+++ b/spec/Services/IdProviderMetadataServiceSpec.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace spec\SimpleSAML\Modules\OpenIDConnect\Services;
+
+use PhpSpec\ObjectBehavior;
+use SimpleSAML\Metadata\MetaDataStorageHandler;
+use SimpleSAML\Modules\OpenIDConnect\Services\IdProviderMetadataService;
+
+class IdProviderMetadataServiceSpec extends ObjectBehavior
+{
+    public const IDP_HOSTED_METADATA = [
+        'host' => '__DEFAULT__',
+        'privatekey' => 'idp.example.org.pem',
+        'certificate' => 'idp.example.org.crt',
+        'auth' => 'example-userpass',
+        'attributes.NameFormat' => 'urn:oasis:names:tc:SAML:2.0:attrname-format:uri',
+        'authproc' => [
+            100 => [
+                'class' => 'core:AttributeMap',
+                0 => 'name2oid',
+            ],
+        ],
+        'entityid' => 'https://idp.example.org/saml2/idp/metadata.php',
+        'metadata-index' => 'https://idp.example.org/saml2/idp/metadata.php',
+        'metadata-set' => 'saml20-idp-hosted',
+    ];
+
+    public function let(
+        MetaDataStorageHandler $metaDataStorageHandler
+    ): void {
+        $this->beConstructedWith($metaDataStorageHandler);
+    }
+
+    public function it_is_initializable()
+    {
+        $this->shouldHaveType(IdProviderMetadataService::class);
+    }
+
+    public function it_returns_expected_metadata(
+        MetaDataStorageHandler $metaDataStorageHandler
+    ): void {
+        $metaDataStorageHandler->getMetaDataCurrent('saml20-idp-hosted')
+            ->shouldBeCalled()
+            ->willReturn(self::IDP_HOSTED_METADATA);
+
+        $this->getMetadata()->shouldBe(self::IDP_HOSTED_METADATA);
+    }
+}

--- a/spec/Services/OidcProviderMetadataServiceSpec.php
+++ b/spec/Services/OidcProviderMetadataServiceSpec.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace spec\SimpleSAML\Modules\OpenIDConnect\Services;
+
+use PhpSpec\ObjectBehavior;
+use SimpleSAML\Modules\OpenIDConnect\Services\ConfigurationService;
+use SimpleSAML\Modules\OpenIDConnect\Services\OidcProviderMetadataService;
+
+class OidcProviderMetadataServiceSpec extends ObjectBehavior
+{
+    public function let(
+        ConfigurationService $configurationService
+    ): void {
+        $configurationService->getOpenIDScopes()->shouldBeCalled()
+            ->willReturn(['openid' => 'openid']);
+
+        $configurationService->getSimpleSAMLSelfURLHost()->shouldBeCalled()
+            ->willReturn('http://localhost');
+        $configurationService->getOpenIdConnectModuleURL('authorize.php')
+            ->willReturn('http://localhost/authorize.php');
+        $configurationService->getOpenIdConnectModuleURL('access_token.php')
+            ->willReturn('http://localhost/access_token.php');
+        $configurationService->getOpenIdConnectModuleURL('userinfo.php')
+            ->willReturn('http://localhost/userinfo.php');
+        $configurationService->getOpenIdConnectModuleURL('jwks.php')
+            ->willReturn('http://localhost/jwks.php');
+
+        $this->beConstructedWith($configurationService);
+    }
+
+    public function it_is_initializable()
+    {
+        $this->shouldHaveType(OidcProviderMetadataService::class);
+    }
+
+    public function it_returns_expected_metadata(): void
+    {
+        $this->getMetadata()->shouldBe([
+            'issuer' => 'http://localhost',
+            'authorization_endpoint' => 'http://localhost/authorize.php',
+            'token_endpoint' => 'http://localhost/access_token.php',
+            'userinfo_endpoint' => 'http://localhost/userinfo.php',
+            'jwks_uri' => 'http://localhost/jwks.php',
+            'scopes_supported' => ['openid'],
+            'response_types_supported' => ['code', 'token'],
+            'subject_types_supported' => ['public'],
+            'id_token_signing_alg_values_supported' => ['RS256'],
+            'code_challenge_methods_supported' => ['plain', 'S256'],
+        ]);
+    }
+}


### PR DESCRIPTION
This pull requests provides additional and optional configuration option 'authproc.oidc', which enables designating specific Auth Proc filters which will only run during OIDC authN. 

Regular SAML related processing filters are still NOT executed during OIDC authN, mainly because different parties are included in the authN process, main difference being between SAML Service Provider and OIDC Relying Party (OIDC client). 

This also means that the authN state array which will be availabe to OIDC filters will be different than the state array available during the SAML authN.  At the moment, during the OIDC authN only the following SAML authN data will be available: 
* 'Attributes', 
* 'Authority'
* 'AuthnInstant'
* 'Expire'
* 'IdPMetadata'
* 'Source'

In addition to that, the following OIDC related data will be available in the state array:
* 'OidcProviderMetadata' - contains information otherwise available from the OIDC configuration URL.
* 'OidcRelyingPartyMetadata' - contains information about the OIDC client making the authN request.
* 'OidcAuthorizationRequestParameters' - contains relevant authorization request query parameters.

This is my proposition, however, I'm open if any of the mentioned data should be keyed differently, if any data should be added or similar (I have added mentioned data because it includes all the information I need for our logging purposes). 

At the moment there is no support for showing a page to the user in a filter, and then resuming the filtering. Despite that I think this is still useful because it opens the possibility to use filters which can manage attributes, or filters for logging or similar.