### PR TITLE
Fix refresh token deletion

### DIFF
--- a/lib/Server/ResponseTypes/IdTokenResponse.php
+++ b/lib/Server/ResponseTypes/IdTokenResponse.php
@@ -102,7 +102,7 @@ class IdTokenResponse extends BearerTokenResponse implements NonceResponseTypeIn
 
         $token = $builder->getToken(
             $this->configurationService->getSigner(),
-            new Key($this->privateKey->getKeyPath(), $this->privateKey->getPassPhrase())
+            new Key($this->privateKey->getKeyPath(), $this->privateKey->getPassPhrase() ?? '')
         );
 
         return [


### PR DESCRIPTION
This is a suggestion to take into account the refresh token duration, when deleting access token using cron task.

Since the deletion of access token will automatically delete corresponding refresh token (on delete cascade is implemented), it is possible to delete valid (not yet expired) refresh tokens, which will break refresh token flow (which is implemented). This is highly possible with default token duration values / cron tags (access token being short lived, refresh token long lived, and cron tag being hourly).

This pull requests adjusts the access token delete SQL to only delete access token if the corresponding refresh token is also expired, that is there is no refresh token which is not yet expired (or it simply doesn't exists).