### PR TITLE
Force json response in OIDC controllers

### DIFF
--- a/www/access_token.php
+++ b/www/access_token.php
@@ -15,4 +15,4 @@
 use SimpleSAML\Modules\OpenIDConnect\Controller\OAuth2AccessTokenController;
 use SimpleSAML\Modules\OpenIDConnect\Services\RoutingService;
 
-RoutingService::call(OAuth2AccessTokenController::class, false);
+RoutingService::call(OAuth2AccessTokenController::class, false, true);

--- a/www/authorize.php
+++ b/www/authorize.php
@@ -15,4 +15,4 @@
 use SimpleSAML\Modules\OpenIDConnect\Controller\OAuth2AuthorizationController;
 use SimpleSAML\Modules\OpenIDConnect\Services\RoutingService;
 
-RoutingService::call(OAuth2AuthorizationController::class, false);
+RoutingService::call(OAuth2AuthorizationController::class, false, true);

--- a/www/jwks.php
+++ b/www/jwks.php
@@ -15,4 +15,4 @@
 use SimpleSAML\Modules\OpenIDConnect\Controller\OpenIdConnectJwksController;
 use SimpleSAML\Modules\OpenIDConnect\Services\RoutingService;
 
-RoutingService::call(OpenIdConnectJwksController::class, false);
+RoutingService::call(OpenIdConnectJwksController::class, false, true);

--- a/www/openid-configuration.php
+++ b/www/openid-configuration.php
@@ -15,4 +15,4 @@
 use SimpleSAML\Modules\OpenIDConnect\Controller\OpenIdConnectDiscoverConfigurationController;
 use SimpleSAML\Modules\OpenIDConnect\Services\RoutingService;
 
-RoutingService::call(OpenIdConnectDiscoverConfigurationController::class, false);
+RoutingService::call(OpenIdConnectDiscoverConfigurationController::class, false, true);

--- a/www/userinfo.php
+++ b/www/userinfo.php
@@ -15,4 +15,4 @@
 use SimpleSAML\Modules\OpenIDConnect\Controller\OpenIdConnectUserInfoController;
 use SimpleSAML\Modules\OpenIDConnect\Services\RoutingService;
 
-RoutingService::call(OpenIdConnectUserInfoController::class, false);
+RoutingService::call(OpenIdConnectUserInfoController::class, false, true);


### PR DESCRIPTION
Right now, controllers only send a JSON response error if clients sends `Accept: application/json` in headers.

Changed routing service with a jsonResponse parameter. OIDC endpoint controllers use it to send always a JSON response.