### PR TITLE
Set token_endpoint_auth_methods_supported

### DIFF
--- a/lib/Services/OidcOpenIdProviderMetadataService.php
+++ b/lib/Services/OidcOpenIdProviderMetadataService.php
@@ -44,6 +44,7 @@ class OidcOpenIdProviderMetadataService
         $this->metadata['subject_types_supported'] = ['public'];
         $this->metadata['id_token_signing_alg_values_supported'] = ['RS256'];
         $this->metadata['code_challenge_methods_supported'] = ['plain', 'S256'];
+        $this->metadata['token_endpoint_auth_methods_supported'] = ['client_secret_post', 'client_secret_basic'];
     }
 
     /**

--- a/spec/Services/OidcOpenIdProviderMetadataServiceSpec.php
+++ b/spec/Services/OidcOpenIdProviderMetadataServiceSpec.php
@@ -46,6 +46,7 @@ class OidcOpenIdProviderMetadataServiceSpec extends ObjectBehavior
             'subject_types_supported' => ['public'],
             'id_token_signing_alg_values_supported' => ['RS256'],
             'code_challenge_methods_supported' => ['plain', 'S256'],
+            'token_endpoint_auth_methods_supported' => ['client_secret_post', 'client_secret_basic'],
         ]);
     }
 }


### PR DESCRIPTION
Current implementation supports client_secret_posta and client_secret_basic.

Closes #109 