### PR TITLE
wip: Feauture/request claims

### DIFF
--- a/lib/ClaimTranslatorExtractor.php
+++ b/lib/ClaimTranslatorExtractor.php
@@ -205,13 +205,13 @@ class ClaimTranslatorExtractor extends ClaimExtractor
     public function extractAdditionalIdTokenClaims(?array $claimsRequest, array $claims): array
     {
         $idTokenClaims = $claimsRequest['id_token'] ?? [];
-        return $this->extractAdditonalClaims($idTokenClaims, $claims);
+        return $this->extractAdditionalClaims($idTokenClaims, $claims);
     }
 
     public function extractAdditionalUserInfoClaims(?array $claimsRequest, array $claims): array
     {
         $userInfoClaims = $claimsRequest['userinfo'] ?? [];
-        return $this->extractAdditonalClaims($userInfoClaims, $claims);
+        return $this->extractAdditionalClaims($userInfoClaims, $claims);
     }
 
     /**
@@ -221,7 +221,7 @@ class ClaimTranslatorExtractor extends ClaimExtractor
      * @param array $claims
      * @return array
      */
-    private function extractAdditonalClaims(array $requestedClaims, array $claims): array
+    private function extractAdditionalClaims(array $requestedClaims, array $claims): array
     {
         if (empty($requestedClaims)) {
             return [];

--- a/lib/Controller/OpenIdConnectUserInfoController.php
+++ b/lib/Controller/OpenIdConnectUserInfoController.php
@@ -23,6 +23,7 @@ use SimpleSAML\Modules\OpenIDConnect\Repositories\AccessTokenRepository;
 use SimpleSAML\Modules\OpenIDConnect\Repositories\UserRepository;
 use Laminas\Diactoros\Response\JsonResponse;
 use Laminas\Diactoros\ServerRequest;
+use SimpleSAML\Modules\OpenIDConnect\Services\RequestedClaimsEncoderService;
 
 class OpenIdConnectUserInfoController
 {
@@ -68,6 +69,10 @@ class OpenIdConnectUserInfoController
         $user = $this->getUser($tokenId);
 
         $claims = $this->claimTranslatorExtractor->extract($scopes, $user->getClaims());
+        //TODO: decide how claims should be persisted
+        $requestedClaims =  (new RequestedClaimsEncoderService())->decodeScopesToRequestedClaims($scopes);
+        $additionalClaims = $this->claimTranslatorExtractor->extractAdditionalUserInfoClaims($requestedClaims, $user->getClaims());
+        $claims = array_merge($additionalClaims, $claims);
 
         return new JsonResponse($claims);
     }

--- a/lib/Controller/OpenIdConnectUserInfoController.php
+++ b/lib/Controller/OpenIdConnectUserInfoController.php
@@ -47,16 +47,23 @@ class OpenIdConnectUserInfoController
      */
     private $claimTranslatorExtractor;
 
+    /**
+     * @var RequestedClaimsEncoderService
+     */
+    private $requestedClaimsEncoderService;
+
     public function __construct(
         ResourceServer $resourceServer,
         AccessTokenRepository $accessTokenRepository,
         UserRepository $userRepository,
-        ClaimTranslatorExtractor $claimTranslatorExtractor
+        ClaimTranslatorExtractor $claimTranslatorExtractor,
+        RequestedClaimsEncoderService $requestedClaimsEncoderService
     ) {
         $this->resourceServer = $resourceServer;
         $this->accessTokenRepository = $accessTokenRepository;
         $this->userRepository = $userRepository;
         $this->claimTranslatorExtractor = $claimTranslatorExtractor;
+        $this->requestedClaimsEncoderService = $requestedClaimsEncoderService;
     }
 
     public function __invoke(ServerRequest $request): JsonResponse
@@ -69,8 +76,7 @@ class OpenIdConnectUserInfoController
         $user = $this->getUser($tokenId);
 
         $claims = $this->claimTranslatorExtractor->extract($scopes, $user->getClaims());
-        //TODO: decide how claims should be persisted
-        $requestedClaims =  (new RequestedClaimsEncoderService())->decodeScopesToRequestedClaims($scopes);
+        $requestedClaims =  $this->requestedClaimsEncoderService->decodeScopesToRequestedClaims($scopes);
         $additionalClaims = $this->claimTranslatorExtractor->extractAdditionalUserInfoClaims($requestedClaims, $user->getClaims());
         $claims = array_merge($additionalClaims, $claims);
 

--- a/lib/Entity/AuthCodeEntity.php
+++ b/lib/Entity/AuthCodeEntity.php
@@ -53,6 +53,10 @@ class AuthCodeEntity implements OidcAuthCodeEntityInterface, MementoInterface
         $authCode->isRevoked = (bool) $state['is_revoked'];
         $authCode->redirectUri = $state['redirect_uri'];
         $authCode->nonce = $state['nonce'];
+//        if (array_key_exists('claims', $state)) {
+//            $authCode->claims = json_decode($state['claims']);
+//        }
+
 
         return $authCode;
     }
@@ -68,6 +72,7 @@ class AuthCodeEntity implements OidcAuthCodeEntityInterface, MementoInterface
             'is_revoked' => (int) $this->isRevoked(),
             'redirect_uri' => $this->getRedirectUri(),
             'nonce' => $this->getNonce(),
+//            'claims' => json_encode($this->getClaims()),
         ];
     }
 }

--- a/lib/Entity/Interfaces/OidcAuthCodeEntityInterface.php
+++ b/lib/Entity/Interfaces/OidcAuthCodeEntityInterface.php
@@ -15,4 +15,16 @@ interface OidcAuthCodeEntityInterface extends AuthCodeEntityInterface
      * @param string $nonce
      */
     public function setNonce(string $nonce): void;
+
+    /**
+     * @return \stdClass|null
+     */
+    public function getClaims(): ?\stdClass;
+
+
+    /**
+     * @param \stdClass|null $claims
+     */
+    public function setClaims(?\stdClass $claims): void;
+
 }

--- a/lib/Entity/Interfaces/OidcAuthCodeEntityInterface.php
+++ b/lib/Entity/Interfaces/OidcAuthCodeEntityInterface.php
@@ -17,14 +17,14 @@ interface OidcAuthCodeEntityInterface extends AuthCodeEntityInterface
     public function setNonce(string $nonce): void;
 
     /**
-     * @return \stdClass|null
+     * @return array|null
      */
-    public function getClaims(): ?\stdClass;
+    public function getClaims(): ?array;
 
 
     /**
-     * @param \stdClass|null $claims
+     * @param array|null $claims
      */
-    public function setClaims(?\stdClass $claims): void;
+    public function setClaims(?array $claims): void;
 
 }

--- a/lib/Entity/Traits/OidcAuthCodeTrait.php
+++ b/lib/Entity/Traits/OidcAuthCodeTrait.php
@@ -14,6 +14,11 @@ trait OidcAuthCodeTrait
     protected $nonce;
 
     /**
+     * @var null|\stdClass
+     */
+    protected $claims;
+
+    /**
      * @inheritDoc
      */
     public function getNonce(): ?string
@@ -27,5 +32,21 @@ trait OidcAuthCodeTrait
     public function setNonce($nonce): void
     {
         $this->nonce = $nonce;
+    }
+
+    /**
+     * @return \stdClass|null
+     */
+    public function getClaims(): ?\stdClass
+    {
+        return $this->claims;
+    }
+
+    /**
+     * @param \stdClass|null $claims
+     */
+    public function setClaims(?\stdClass $claims): void
+    {
+        $this->claims = $claims;
     }
 }

--- a/lib/Entity/Traits/OidcAuthCodeTrait.php
+++ b/lib/Entity/Traits/OidcAuthCodeTrait.php
@@ -14,7 +14,7 @@ trait OidcAuthCodeTrait
     protected $nonce;
 
     /**
-     * @var null|\stdClass
+     * @var null|array
      */
     protected $claims;
 
@@ -35,17 +35,17 @@ trait OidcAuthCodeTrait
     }
 
     /**
-     * @return \stdClass|null
+     * @return array|null
      */
-    public function getClaims(): ?\stdClass
+    public function getClaims(): ?array
     {
         return $this->claims;
     }
 
     /**
-     * @param \stdClass|null $claims
+     * @param array|null $claims
      */
-    public function setClaims(?\stdClass $claims): void
+    public function setClaims(?array $claims): void
     {
         $this->claims = $claims;
     }

--- a/lib/Factories/Grant/AuthCodeGrantFactory.php
+++ b/lib/Factories/Grant/AuthCodeGrantFactory.php
@@ -17,6 +17,7 @@ namespace SimpleSAML\Modules\OpenIDConnect\Factories\Grant;
 use SimpleSAML\Modules\OpenIDConnect\Server\Grants\AuthCodeGrant;
 use SimpleSAML\Modules\OpenIDConnect\Repositories\AuthCodeRepository;
 use SimpleSAML\Modules\OpenIDConnect\Repositories\RefreshTokenRepository;
+use SimpleSAML\Modules\OpenIDConnect\Services\RequestedClaimsEncoderService;
 use SimpleSAML\Modules\OpenIDConnect\Utils\Checker\RequestRulesManager;
 
 class AuthCodeGrantFactory
@@ -45,18 +46,26 @@ class AuthCodeGrantFactory
      */
     private $requestRulesManager;
 
+    /**
+     * @var RequestedClaimsEncoderService
+     */
+    private $requestedClaimsEncoderService;
+
+
     public function __construct(
         AuthCodeRepository $authCodeRepository,
         RefreshTokenRepository $refreshTokenRepository,
         \DateInterval $refreshTokenDuration,
         \DateInterval $authCodeDuration,
-        RequestRulesManager $requestRulesManager
+        RequestRulesManager $requestRulesManager,
+        RequestedClaimsEncoderService $requestedClaimsEncoderService
     ) {
         $this->authCodeRepository = $authCodeRepository;
         $this->refreshTokenRepository = $refreshTokenRepository;
         $this->refreshTokenDuration = $refreshTokenDuration;
         $this->authCodeDuration = $authCodeDuration;
         $this->requestRulesManager = $requestRulesManager;
+        $this->requestedClaimsEncoderService = $requestedClaimsEncoderService;
     }
 
     public function build(): AuthCodeGrant
@@ -65,7 +74,8 @@ class AuthCodeGrantFactory
             $this->authCodeRepository,
             $this->refreshTokenRepository,
             $this->authCodeDuration,
-            $this->requestRulesManager
+            $this->requestRulesManager,
+            $this->requestedClaimsEncoderService
         );
         $authCodeGrant->setRefreshTokenTTL($this->refreshTokenDuration);
 

--- a/lib/Factories/Grant/ImplicitGrantFactory.php
+++ b/lib/Factories/Grant/ImplicitGrantFactory.php
@@ -17,6 +17,7 @@ namespace SimpleSAML\Modules\OpenIDConnect\Factories\Grant;
 use DateInterval;
 use SimpleSAML\Modules\OpenIDConnect\Server\Grants\ImplicitGrant;
 use SimpleSAML\Modules\OpenIDConnect\Services\IdTokenBuilder;
+use SimpleSAML\Modules\OpenIDConnect\Services\RequestedClaimsEncoderService;
 use SimpleSAML\Modules\OpenIDConnect\Utils\Checker\RequestRulesManager;
 
 class ImplicitGrantFactory
@@ -36,11 +37,21 @@ class ImplicitGrantFactory
      */
     protected $requestRulesManager;
 
-    public function __construct(IdTokenBuilder $idTokenBuilder, DateInterval $accessTokenDuration, RequestRulesManager $requestRulesManager)
-    {
+    /**
+     * @var RequestedClaimsEncoderService
+     */
+    private $requestedClaimsEncoderService;
+
+    public function __construct(
+        IdTokenBuilder $idTokenBuilder,
+        DateInterval $accessTokenDuration,
+        RequestRulesManager $requestRulesManager,
+        RequestedClaimsEncoderService $requestedClaimsEncoderService
+    ) {
         $this->idTokenBuilder = $idTokenBuilder;
         $this->accessTokenDuration = $accessTokenDuration;
         $this->requestRulesManager = $requestRulesManager;
+        $this->requestedClaimsEncoderService = $requestedClaimsEncoderService;
     }
 
     public function build(): ImplicitGrant
@@ -49,7 +60,8 @@ class ImplicitGrantFactory
             $this->idTokenBuilder,
             $this->accessTokenDuration,
             '#',
-            $this->requestRulesManager
+            $this->requestRulesManager,
+            $this->requestedClaimsEncoderService
         );
     }
 }

--- a/lib/Factories/IdTokenBuilderFactory.php
+++ b/lib/Factories/IdTokenBuilderFactory.php
@@ -20,6 +20,7 @@ use SimpleSAML\Modules\OpenIDConnect\Repositories\UserRepository;
 use SimpleSAML\Modules\OpenIDConnect\Server\ResponseTypes\IdTokenResponse;
 use SimpleSAML\Modules\OpenIDConnect\Services\ConfigurationService;
 use SimpleSAML\Modules\OpenIDConnect\Services\IdTokenBuilder;
+use SimpleSAML\Modules\OpenIDConnect\Services\RequestedClaimsEncoderService;
 use SimpleSAML\Utils\Config;
 
 class IdTokenBuilderFactory
@@ -43,17 +44,23 @@ class IdTokenBuilderFactory
      */
     private $privateKey;
 
+    /**
+     * @var RequestedClaimsEncoderService
+     */
+    private $requestedClaimsEncoderService;
 
     public function __construct(
         UserRepository $userRepository,
         ConfigurationService $configurationService,
         ClaimTranslatorExtractor $claimTranslatorExtractor,
-        CryptKey $privateKey
+        CryptKey $privateKey,
+        RequestedClaimsEncoderService $requestedClaimsEncoderService
     ) {
         $this->userRepository = $userRepository;
         $this->configurationService = $configurationService;
         $this->claimTranslatorExtractor = $claimTranslatorExtractor;
         $this->privateKey = $privateKey;
+        $this->requestedClaimsEncoderService = $requestedClaimsEncoderService;
     }
 
     public function build(): IdTokenBuilder
@@ -62,7 +69,8 @@ class IdTokenBuilderFactory
             $this->userRepository,
             $this->claimTranslatorExtractor,
             $this->configurationService,
-            $this->privateKey
+            $this->privateKey,
+            $this->requestedClaimsEncoderService
         );
     }
 }

--- a/lib/Repositories/AuthCodeRepository.php
+++ b/lib/Repositories/AuthCodeRepository.php
@@ -50,6 +50,8 @@ class AuthCodeRepository extends AbstractDatabaseRepository implements OidcAuthC
         $stmt = sprintf(
             "INSERT INTO %s (id, scopes, expires_at, user_id, client_id, is_revoked, redirect_uri, nonce) "
                 . "VALUES (:id, :scopes, :expires_at, :user_id, :client_id, :is_revoked, :redirect_uri, :nonce)",
+//            "INSERT INTO %s (id, scopes, expires_at, user_id, client_id, is_revoked, redirect_uri, nonce, claims) "
+//                . "VALUES (:id, :scopes, :expires_at, :user_id, :client_id, :is_revoked, :redirect_uri, :nonce, :claims)",
             $this->getTableName()
         );
 

--- a/lib/Server/RequestTypes/AuthorizationRequest.php
+++ b/lib/Server/RequestTypes/AuthorizationRequest.php
@@ -16,6 +16,13 @@ class AuthorizationRequest extends OAuth2AuthorizationRequest
      */
     protected $authTime;
 
+    /**
+     * The JSON object sent as `claims` request parameter.
+     * @link https://openid.net/specs/openid-connect-core-1_0.html#ClaimsParameter
+     * @var array|null
+     */
+    protected $claims;
+
     public static function fromOAuth2AuthorizationRequest(OAuth2AuthorizationRequest $oAuth2authorizationRequest): AuthorizationRequest
     {
         $authorizationRequest = new self();
@@ -66,4 +73,22 @@ class AuthorizationRequest extends OAuth2AuthorizationRequest
     {
         $this->authTime = $authTime;
     }
+
+    /**
+     * @return array|null
+     */
+    public function getClaims(): ?array
+    {
+        return $this->claims;
+    }
+
+    /**
+     * @param array|null $claims
+     */
+    public function setClaims(?array $claims): void
+    {
+        $this->claims = $claims;
+    }
+
+
 }

--- a/lib/Services/Container.php
+++ b/lib/Services/Container.php
@@ -220,7 +220,7 @@ class Container implements ContainerInterface
         $oAuth2ImplicitGrantFactory = new OAuth2ImplicitGrantFactory($accessTokenDuration, $requestRuleManager);
         $this->services[OAuth2ImplicitGrant::class] = $oAuth2ImplicitGrantFactory->build();
 
-        $implicitGrantFactory = new ImplicitGrantFactory($this->services[IdTokenBuilder::class], $accessTokenDuration, $requestRuleManager);
+        $implicitGrantFactory = new ImplicitGrantFactory($this->services[IdTokenBuilder::class], $accessTokenDuration, $requestRuleManager, $requestedClaimsEncoderService);
         $this->services[ImplicitGrant::class] = $implicitGrantFactory->build();
 
         $refreshTokenGrantFactory = new RefreshTokenGrantFactory(

--- a/lib/Services/IdTokenBuilder.php
+++ b/lib/Services/IdTokenBuilder.php
@@ -34,16 +34,23 @@ class IdTokenBuilder
      */
     private $privateKey;
 
+    /**
+     * @var RequestedClaimsEncoderService
+     */
+    private $requestedClaimsEncoderService;
+
     public function __construct(
         IdentityProviderInterface $identityProvider,
         ClaimTranslatorExtractor $claimExtractor,
         ConfigurationService $configurationService,
-        CryptKey $privateKey
+        CryptKey $privateKey,
+        RequestedClaimsEncoderService $requestedClaimsEncoderService
     ) {
         $this->identityProvider = $identityProvider;
         $this->claimExtractor = $claimExtractor;
         $this->configurationService = $configurationService;
         $this->privateKey = $privateKey;
+        $this->requestedClaimsEncoderService = $requestedClaimsEncoderService;
     }
 
     public function build(AccessTokenEntityInterface $accessToken, ?string $nonce, ?int $authTime)
@@ -77,8 +84,7 @@ class IdTokenBuilder
 
         // Need a claim factory here to reduce the number of claims by provided scope.
         $claims = $this->claimExtractor->extract($accessToken->getScopes(), $userEntity->getClaims());
-        //TODO: decide how claims should be persisted
-        $requestedClaims =  (new RequestedClaimsEncoderService())->decodeScopesToRequestedClaims($accessToken->getScopes());
+        $requestedClaims =  $this->requestedClaimsEncoderService->decodeScopesToRequestedClaims($accessToken->getScopes());
         $additionalClaims = $this->claimExtractor->extractAdditionalIdTokenClaims($requestedClaims, $userEntity->getClaims());
         $claims = array_merge($additionalClaims, $claims);
 

--- a/lib/Services/RequestedClaimsEncoderService.php
+++ b/lib/Services/RequestedClaimsEncoderService.php
@@ -9,7 +9,7 @@ use SimpleSAML\Modules\OpenIDConnect\Entity\ScopeEntity;
 /**
  * OIDC allows clients to request specific claims, and not just scopes. The oauth2 server library
  * does not seem to have an easy way to tie into authz and refresh token generation, making it difficult to
- * associated these claims with tokens. A short term workaround is to encode them as scope
+ * associated these claims with tokens. A workaround is to encode them as scope
  * Class RequestedClaimsEncoderService
  * @package SimpleSAML\Modules\OpenIDConnect\Services
  */

--- a/lib/Services/RequestedClaimsEncoderService.php
+++ b/lib/Services/RequestedClaimsEncoderService.php
@@ -1,0 +1,43 @@
+<?php
+
+
+namespace SimpleSAML\Modules\OpenIDConnect\Services;
+
+use League\OAuth2\Server\Entities\ScopeEntityInterface;
+use SimpleSAML\Modules\OpenIDConnect\Entity\ScopeEntity;
+
+/**
+ * OIDC allows clients to request specific claims, and not just scopes. The oauth2 server library
+ * does not seem to have an easy way to tie into authz and refresh token generation, making it difficult to
+ * associated these claims with tokens. A short term workaround is to encode them as scope
+ * Class RequestedClaimsEncoderService
+ * @package SimpleSAML\Modules\OpenIDConnect\Services
+ */
+class RequestedClaimsEncoderService
+{
+    private $claimPrefix = '_claims_requested_';
+
+    public function encodeRequestedClaimsAsScope($requestedClaims): ?ScopeEntityInterface
+    {
+        if (empty($requestedClaims)) {
+            return null;
+        }
+        return ScopeEntity::fromData(
+            $this->claimPrefix . base64_encode(json_encode($requestedClaims)),
+            'workaround for storing request claims'
+        );
+    }
+
+    public function decodeScopesToRequestedClaims(array $scopes): ?array
+    {
+        foreach ($scopes as $scope) {
+            $scopeName = ($scope instanceof ScopeEntityInterface) ? $scope->getIdentifier() : $scope;
+            $matches = [];
+            if (preg_match('/^' . preg_quote($this->claimPrefix) . '(.*)$/', $scopeName, $matches) === 1) {
+                return json_decode(base64_decode($matches[1]), true);
+            }
+        }
+        return null;
+    }
+
+}

--- a/lib/Utils/Checker/Rules/RequestedClaimsRule.php
+++ b/lib/Utils/Checker/Rules/RequestedClaimsRule.php
@@ -1,0 +1,63 @@
+<?php
+
+
+namespace SimpleSAML\Modules\OpenIDConnect\Utils\Checker\Rules;
+
+
+use League\OAuth2\Server\Repositories\ClientRepositoryInterface;
+use OpenIDConnectServer\ClaimExtractor;
+use Psr\Http\Message\ServerRequestInterface;
+use SimpleSAML\Modules\OpenIDConnect\Entity\Interfaces\ClientEntityInterface;
+use SimpleSAML\Modules\OpenIDConnect\Server\Exceptions\OidcServerException;
+use SimpleSAML\Modules\OpenIDConnect\Utils\Checker\Interfaces\ResultBagInterface;
+use SimpleSAML\Modules\OpenIDConnect\Utils\Checker\Interfaces\ResultInterface;
+use SimpleSAML\Modules\OpenIDConnect\Utils\Checker\Result;
+
+class RequestedClaimsRule extends AbstractRule
+{
+    private $clientRepository;
+
+    private $claimExtractor;
+
+    public function __construct(ClientRepositoryInterface $clientRepository, ClaimExtractor $claimExtractor)
+    {
+        $this->clientRepository = $clientRepository;
+        $this->claimExtractor = $claimExtractor;
+    }
+
+
+    public function checkRule(
+        ServerRequestInterface $request,
+        ResultBagInterface $currentResultBag,
+        array $data
+    ): ?ResultInterface {
+        $claimsParam = $request->getQueryParams()['claims'] ?? null;
+        $claims = json_decode($claimsParam, true);
+        if (is_null($claims)) {
+            return null;
+        }
+        $clientId = $request->getQueryParams()['client_id'] ?? $request->getServerParams()['PHP_AUTH_USER'] ?? null;
+
+        if ($clientId === null) {
+            throw OidcServerException::invalidRequest('client_id');
+        }
+
+        $client = $this->clientRepository->getClientEntity($clientId);
+        if ($client instanceof ClientEntityInterface === false) {
+            throw OidcServerException::invalidClient($request);
+        }
+            $authorizedClaims = [];
+            foreach ($client->getScopes() as $scope) {
+                $claimSet = $this->claimExtractor->getClaimSet($scope);
+                if ($claimSet) {
+                    array_merge($authorizedClaims, $claimSet->getClaims());
+                }
+            }
+
+            //TODO: filter id_token and user_info claims
+           // iterate claims and unset things
+
+        return new Result($this->getKey(), $claims);
+
+    }
+}

--- a/spec/Controller/OpenIdConnectUserInfoControllerSpec.php
+++ b/spec/Controller/OpenIdConnectUserInfoControllerSpec.php
@@ -37,6 +37,7 @@ class OpenIdConnectUserInfoControllerSpec extends ObjectBehavior
         UserRepository $userRepository,
         ClaimTranslatorExtractor $claimTranslatorExtractor
     ) {
+        $claimTranslatorExtractor->extractAdditionalUserInfoClaims(null, ['mail' => ['userid@localhost.localdomain']])->willReturn([]);
         $this->beConstructedWith($resourceServer, $accessTokenRepository, $userRepository, $claimTranslatorExtractor);
     }
 

--- a/spec/Controller/OpenIdConnectUserInfoControllerSpec.php
+++ b/spec/Controller/OpenIdConnectUserInfoControllerSpec.php
@@ -25,6 +25,7 @@ use SimpleSAML\Modules\OpenIDConnect\Repositories\AccessTokenRepository;
 use SimpleSAML\Modules\OpenIDConnect\Repositories\UserRepository;
 use Laminas\Diactoros\Response\JsonResponse;
 use Laminas\Diactoros\ServerRequest;
+use SimpleSAML\Modules\OpenIDConnect\Services\RequestedClaimsEncoderService;
 
 class OpenIdConnectUserInfoControllerSpec extends ObjectBehavior
 {
@@ -38,7 +39,8 @@ class OpenIdConnectUserInfoControllerSpec extends ObjectBehavior
         ClaimTranslatorExtractor $claimTranslatorExtractor
     ) {
         $claimTranslatorExtractor->extractAdditionalUserInfoClaims(null, ['mail' => ['userid@localhost.localdomain']])->willReturn([]);
-        $this->beConstructedWith($resourceServer, $accessTokenRepository, $userRepository, $claimTranslatorExtractor);
+        $requestedClaimsEncoderService = new RequestedClaimsEncoderService();
+        $this->beConstructedWith($resourceServer, $accessTokenRepository, $userRepository, $claimTranslatorExtractor, $requestedClaimsEncoderService);
     }
 
     /**

--- a/spec/Server/ResponseTypes/IdTokenResponseSpec.php
+++ b/spec/Server/ResponseTypes/IdTokenResponseSpec.php
@@ -84,7 +84,8 @@ class IdTokenResponseSpec extends ObjectBehavior
             $identityProvider->getWrappedObject(),
             new ClaimTranslatorExtractor(),
             $configurationService->getWrappedObject(),
-            $privateKey
+            $privateKey,
+            new RequestedClaimsEncoderService()
         );
 
         $this->beConstructedWith($idTokenBuilder);

--- a/tests/ClaimTranslatorExtractorTest.php
+++ b/tests/ClaimTranslatorExtractorTest.php
@@ -154,4 +154,18 @@ class ClaimTranslatorExtractorTest extends TestCase
         $claimTranslator = new ClaimTranslatorExtractor([$claimSet], $translate);
         $claimTranslator->extract(['typeConversion'], $userAttributes);
     }
+
+    public function testExtractRequestClaims(): void
+    {
+        $claimTranslator = new ClaimTranslatorExtractor();
+        $requestClaims = [
+          "userinfo" => [
+              "name" => ['essential' => true]
+          ]
+        ];
+
+        $claims = $claimTranslator->extractAdditionalUserInfoClaims($requestClaims, ['cn' => ['bob']]);
+        $this->assertEquals(['name' => 'bob'], $claims);
+
+    }
 }

--- a/tests/Utils/Checker/Rules/RequestedClaimsRuleTest.php
+++ b/tests/Utils/Checker/Rules/RequestedClaimsRuleTest.php
@@ -1,0 +1,73 @@
+<?php
+
+
+namespace Tests\SimpleSAML\Modules\OpenIDConnect\Utils\Checker\Rules;
+
+
+use League\OAuth2\Server\Repositories\ClientRepositoryInterface;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\ServerRequestInterface;
+use SimpleSAML\Modules\OpenIDConnect\ClaimTranslatorExtractor;
+use SimpleSAML\Modules\OpenIDConnect\Entity\Interfaces\ClientEntityInterface;
+use SimpleSAML\Modules\OpenIDConnect\Utils\Checker\ResultBag;
+use SimpleSAML\Modules\OpenIDConnect\Utils\Checker\Rules\RedirectUriRule;
+use SimpleSAML\Modules\OpenIDConnect\Utils\Checker\Rules\RequestedClaimsRule;
+
+class RequestedClaimsRuleTest extends TestCase
+{
+
+    protected $resultBag;
+    protected $clientStub;
+    protected $request;
+    protected $redirectUri = 'https://some-redirect-uri.org';
+    protected $clientRepository;
+
+
+    protected function setUp(): void
+    {
+        $this->resultBag = new ResultBag();
+        $this->clientStub = $this->createStub(ClientEntityInterface::class);
+        $this->request = $this->createStub(ServerRequestInterface::class);
+        $this->clientRepository = $this->createStub(ClientRepositoryInterface::class);
+        $this->clientRepository->method('getClientEntity')->willReturn($this->clientStub);
+        $this->clientStub->method('getScopes')->willReturn(['openid', 'profile', 'email']);
+    }
+
+    public function testNoRequestedClaims(): void
+    {
+        $rule = new RequestedClaimsRule($this->clientRepository, new ClaimTranslatorExtractor());
+        $resultBag = new ResultBag();
+        $result = $rule->checkRule($this->request, $resultBag, []);
+        $this->assertNull($result);
+    }
+
+    public function testWithClaims(): void
+    {
+        $expectedClaims = [
+            'userinfo'=> [
+                "name" => null,
+                "email" => [
+                    "essential"=> true,
+                    "extras_stuff_not_in_spec" => "should be ignored"
+                ]
+            ],
+            "id_token" => [
+                'name' => [
+                    "essential" => true
+                ]
+            ],
+            "additional_stuff" => [
+                "should be ignored"
+            ]
+        ];
+        $this->request->method('getQueryParams')->willReturn([
+            'claims' => json_encode($expectedClaims),
+            'client_id' => 'abc'
+                                                             ]);
+
+        $rule = new RequestedClaimsRule($this->clientRepository, new ClaimTranslatorExtractor());
+        $resultBag = new ResultBag();
+        $result = $rule->checkRule($this->request, $resultBag, []);
+        $this->assertEquals($expectedClaims, $result->getValue());
+    }
+}

--- a/tests/Utils/Checker/Rules/RequestedClaimsRuleTest.php
+++ b/tests/Utils/Checker/Rules/RequestedClaimsRuleTest.php
@@ -60,8 +60,12 @@ class RequestedClaimsRuleTest extends TestCase
                 "should be ignored"
             ]
         ];
+        $requestedClaims = $expectedClaims;
+        // Add some claims the client is not authorized for
+        $requestedClaims['userinfo']['someClaim'] = null;
+        $requestedClaims['id_token']['secret_password'] = null;
         $this->request->method('getQueryParams')->willReturn([
-            'claims' => json_encode($expectedClaims),
+            'claims' => json_encode($requestedClaims),
             'client_id' => 'abc'
                                                              ]);
 


### PR DESCRIPTION
Allow claims to be requested by name rather than only scope.

The underlying library don't seem to let us associated additional data with a oauth2 token without us duplicating a lot of code. As a workaround this filters and converts requested claims into a custom scope.  We probably need to decide if that is way we want to go to allow this functionality.