### PR TITLE
Fix CORS

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,6 +20,7 @@
         "php": ">=7.2.0",
         "ext-json": "*",
         "ext-openssl": "*",
+        "ext-pdo": "*",
         "laminas/laminas-diactoros": "^2.2.1",
         "laminas/laminas-httphandlerrunner": "^1.1.0",
         "lcobucci/jwt": "^4.1",

--- a/docker/conformance.sql
+++ b/docker/conformance.sql
@@ -7,6 +7,7 @@ INSERT INTO oidc_migration_versions VALUES('20200517071100');
 INSERT INTO oidc_migration_versions VALUES('20200901163000');
 INSERT INTO oidc_migration_versions VALUES('20210714113000');
 INSERT INTO oidc_migration_versions VALUES('20210823141300');
+INSERT INTO oidc_migration_versions VALUES('20210827111300');
 CREATE TABLE oidc_user (
             id VARCHAR(191) PRIMARY KEY NOT NULL,
             claims TEXT,
@@ -59,5 +60,12 @@ CREATE TABLE oidc_auth_code (
                 REFERENCES oidc_user (id) ON DELETE CASCADE,                                 
             CONSTRAINT FK_97D32CA719EB6921 FOREIGN KEY (client_id)
                 REFERENCES oidc_client (id) ON DELETE CASCADE                                            
+        );
+CREATE TABLE oidc_allowed_origin (
+            client_id varchar(191) NOT NULL,
+            origin varchar(191) NOT NULL,
+            PRIMARY KEY (client_id, origin),
+            CONSTRAINT FK_A027AF1E19EB6921 FOREIGN KEY (client_id)
+                REFERENCES oidc_client (id) ON DELETE CASCADE
         );
 COMMIT;

--- a/lib/Controller/ClientShowController.php
+++ b/lib/Controller/ClientShowController.php
@@ -16,6 +16,7 @@ namespace SimpleSAML\Module\oidc\Controller;
 
 use SimpleSAML\Module\oidc\Controller\Traits\GetClientFromRequestTrait;
 use SimpleSAML\Module\oidc\Factories\TemplateFactory;
+use SimpleSAML\Module\oidc\Repositories\AllowedOriginRepository;
 use SimpleSAML\Module\oidc\Repositories\ClientRepository;
 use Laminas\Diactoros\ServerRequest;
 
@@ -28,18 +29,29 @@ class ClientShowController
      */
     private $templateFactory;
 
-    public function __construct(ClientRepository $clientRepository, TemplateFactory $templateFactory)
-    {
+    /**
+     * @var AllowedOriginRepository
+     */
+    private $allowedOriginRepository;
+
+    public function __construct(
+        ClientRepository $clientRepository,
+        AllowedOriginRepository $allowedOriginRepository,
+        TemplateFactory $templateFactory
+    ) {
         $this->clientRepository = $clientRepository;
+        $this->allowedOriginRepository = $allowedOriginRepository;
         $this->templateFactory = $templateFactory;
     }
 
     public function __invoke(ServerRequest $request): \SimpleSAML\XHTML\Template
     {
         $client = $this->getClientFromRequest($request);
+        $allowedOrigins = $this->allowedOriginRepository->get($client->getIdentifier());
 
         return $this->templateFactory->render('oidc:clients/show.twig', [
             'client' => $client,
+            'allowedOrigins' => $allowedOrigins
         ]);
     }
 }

--- a/lib/Form/ClientForm.php
+++ b/lib/Form/ClientForm.php
@@ -23,9 +23,18 @@ class ClientForm extends Form
 {
     /**
      * RFC3986. AppendixB. Parsing a URI Reference with a Regular Expression.
+     * Important if updating regex: also used in JavaScript validation in templates/clients/_form.twig
      */
     public const REGEX_URI = '/^[^:]+:\/\/?[^\s\/$.?#].[^\s]*$/';
-    public const REGEX_ALLOWED_ORIGIN_URL = '/http(s?)\:\/\/[^\s\/$.?#]+\.[^\s\/$.?#]+(\.[^\s\/$.?#]+)*$/i';
+
+    /**
+     * Must have http:// or https:// scheme, and at least one 'domain.top-level-domain' pair, or more subdomains.
+     * Top-level-domain may end with '.'.
+     * No reserved chars allowed, meaning no userinfo, path, query or fragment components. May end with port number.
+     * Important if updating regex: also used in JavaScript validation in templates/clients/_form.twig
+     */
+    public const REGEX_ALLOWED_ORIGIN_URL =
+        "/^http(s?):\/\/[^\s\/!$&'()+,;=.?#@*:]+\.[^\s\/!$&'()+,;=.?#@*]+\.?(\.[^\s\/!$&'()+,;=?#@*:]+)*(:\d{1,5})?$/i";
 
     /**
      * @var \SimpleSAML\Module\oidc\Services\ConfigurationService
@@ -158,7 +167,7 @@ class ClientForm extends Form
             ->setItems($scopes)
             ->setRequired('Select one scope at least');
 
-        $allowedOrigins = $this->addTextArea('allowed_origin', '{oidc:client:allowed_origin}', null, 5);
+        $this->addTextArea('allowed_origin', '{oidc:client:allowed_origin}', null, 5);
     }
 
     protected function getScopes(): array

--- a/lib/Repositories/AllowedOriginRepository.php
+++ b/lib/Repositories/AllowedOriginRepository.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace SimpleSAML\Module\oidc\Repositories;
+
+class AllowedOriginRepository extends AbstractDatabaseRepository
+{
+    public const TABLE_NAME = 'oidc_allowed_origin';
+
+    public function getTableName(): string
+    {
+        return $this->database->applyPrefix(self::TABLE_NAME);
+    }
+
+    public function setClientAllowedOrigins(string $clientId, array $origins): void
+    {
+        $this->deleteClientAllowedOrigins($clientId);
+
+        if (empty($origins)) {
+            return;
+        }
+
+        // Filter duplicates
+
+
+    }
+
+    public function deleteClientAllowedOrigins(string $clientId): void
+    {
+
+    }
+}

--- a/lib/Repositories/AllowedOriginRepository.php
+++ b/lib/Repositories/AllowedOriginRepository.php
@@ -2,6 +2,8 @@
 
 namespace SimpleSAML\Module\oidc\Repositories;
 
+use PDO;
+
 class AllowedOriginRepository extends AbstractDatabaseRepository
 {
     public const TABLE_NAME = 'oidc_allowed_origin';
@@ -11,21 +13,52 @@ class AllowedOriginRepository extends AbstractDatabaseRepository
         return $this->database->applyPrefix(self::TABLE_NAME);
     }
 
-    public function setClientAllowedOrigins(string $clientId, array $origins): void
+    /**
+     * @param string $clientId
+     * @param string[] $origins
+     */
+    public function set(string $clientId, array $origins): void
     {
-        $this->deleteClientAllowedOrigins($clientId);
+        $this->delete($clientId);
+
+        $origins = array_unique(array_filter(array_values($origins)));
 
         if (empty($origins)) {
             return;
         }
 
-        // Filter duplicates
+        $stmt = "INSERT INTO {$this->getTableName()} (client_id, origin) VALUES ";
 
+        $params = [];
+        foreach ($origins as $idx => $origin) {
+            if ($idx > 0) {
+                $stmt .= ',';
+            }
+            $paramClientPlaceholder = 'client_id_' . $idx;
+            $paramOriginPlaceholder = 'origin_' . $idx;
+            $params[$paramClientPlaceholder] = $clientId;
+            $params[$paramOriginPlaceholder] = $origin;
+            $stmt .= "(:$paramClientPlaceholder, :$paramOriginPlaceholder)";
+        }
 
+        $this->database->write($stmt, $params);
     }
 
-    public function deleteClientAllowedOrigins(string $clientId): void
+    public function delete(string $clientId): void
     {
+        $this->database->write(
+            "DELETE FROM {$this->getTableName()} WHERE client_id = :client_id",
+            ['client_id' => $clientId]
+        );
+    }
 
+    public function get(string $clientId): array
+    {
+        $stmt = $this->database->read(
+            "SELECT origin FROM {$this->getTableName()} WHERE client_id = :client_id",
+            ['client_id' => $clientId]
+        );
+
+        return $stmt->fetchAll(PDO::FETCH_COLUMN, 0);
     }
 }

--- a/lib/Repositories/AllowedOriginRepository.php
+++ b/lib/Repositories/AllowedOriginRepository.php
@@ -61,4 +61,14 @@ class AllowedOriginRepository extends AbstractDatabaseRepository
 
         return $stmt->fetchAll(PDO::FETCH_COLUMN, 0);
     }
+
+    public function has(string $origin): bool
+    {
+        $stmt = $this->database->read(
+            "SELECT origin FROM {$this->getTableName()} WHERE origin = :origin LIMIT 1",
+            ['origin' => $origin]
+        );
+
+        return (bool) count($stmt->fetchAll(PDO::FETCH_COLUMN, 0));
+    }
 }

--- a/lib/Services/Container.php
+++ b/lib/Services/Container.php
@@ -37,6 +37,7 @@ use SimpleSAML\Module\oidc\Factories\IdTokenResponseFactory;
 use SimpleSAML\Module\oidc\Factories\ResourceServerFactory;
 use SimpleSAML\Module\oidc\Factories\TemplateFactory;
 use SimpleSAML\Module\oidc\Repositories\AccessTokenRepository;
+use SimpleSAML\Module\oidc\Repositories\AllowedOriginRepository;
 use SimpleSAML\Module\oidc\Repositories\AuthCodeRepository;
 use SimpleSAML\Module\oidc\Repositories\ClientRepository;
 use SimpleSAML\Module\oidc\Repositories\CodeChallengeVerifiersRepository;
@@ -101,6 +102,9 @@ class Container implements ContainerInterface
 
         $scopeRepository = new ScopeRepository($configurationService);
         $this->services[ScopeRepository::class] = $scopeRepository;
+
+        $allowedOriginRepository = new AllowedOriginRepository($configurationService);
+        $this->services[AllowedOriginRepository::class] = $allowedOriginRepository;
 
         $database = Database::getInstance();
         $this->services[Database::class] = $database;

--- a/locales/en/LC_MESSAGES/oidc.po
+++ b/locales/en/LC_MESSAGES/oidc.po
@@ -132,3 +132,12 @@ msgstr "State"
 
 msgid "{oidc:client:csrf_error}"
 msgstr "Your session has expired. Please return to the home page and try again."
+
+msgid "{oidc:client:allowed_origin}"
+msgstr "Allowed Origins"
+
+msgid "{oidc:client:allowed_origin_help}"
+msgstr "If the client is public and running in browser, enter URLs as allowed origins for CORS requests (with http(s))"
+
+msgid "{oidc:client:allowed_origin_not_valid}"
+msgstr "Some of the entered allowed origins are not valid."

--- a/locales/en/LC_MESSAGES/oidc.po
+++ b/locales/en/LC_MESSAGES/oidc.po
@@ -17,7 +17,7 @@ msgid "{oidc:client:description}"
 msgstr "Description"
 
 msgid "{oidc:client:identifier}"
-msgstr "Client id."
+msgstr "Client ID"
 
 msgid "{oidc:client:secret}"
 msgstr "Client secret"
@@ -26,7 +26,7 @@ msgid "{oidc:client:auth_source}"
 msgstr "Auth. source"
 
 msgid "{oidc:client:redirect_uri}"
-msgstr "Redirect URI"
+msgstr "Redirect URIs"
 
 msgid "{oidc:client:scopes}"
 msgstr "Scopes"
@@ -125,7 +125,10 @@ msgid "{oidc:title}"
 msgstr "OpenID Connect Client Registry"
 
 msgid "{oidc:client:is_confidential}"
-msgstr "Secure client"
+msgstr "Confidential client"
+
+msgid "{oidc:client:is_confidential_help}"
+msgstr "Choose if client is confidential or public"
 
 msgid "{oidc:client:state}"
 msgstr "State"
@@ -134,10 +137,10 @@ msgid "{oidc:client:csrf_error}"
 msgstr "Your session has expired. Please return to the home page and try again."
 
 msgid "{oidc:client:allowed_origin}"
-msgstr "Allowed Origins"
+msgstr "Allowed origins for public clients"
 
 msgid "{oidc:client:allowed_origin_help}"
-msgstr "If the client is public and running in browser, enter URLs as allowed origins for CORS requests (with http(s))"
+msgstr "URLs as allowed origins for CORS requests, for public clients running in browser (e.g. http(s)://example.org)"
 
 msgid "{oidc:client:allowed_origin_not_valid}"
 msgstr "Some of the entered allowed origins are not valid."

--- a/locales/es/LC_MESSAGES/oidc.po
+++ b/locales/es/LC_MESSAGES/oidc.po
@@ -128,7 +128,10 @@ msgid "{oidc:oidc:title}"
 msgstr "Registro de clientes OpenID Connect"
 
 msgid "{oidc:client:is_confidential}"
-msgstr "Cliente seguro"
+msgstr "Cliente confidencial"
+
+msgid "{oidc:client:is_confidential_help}"
+msgstr "Elija si el cliente es confidencial o público."
 
 msgid "{oidc:client:state}"
 msgstr "Estado"

--- a/spec/Controller/ClientCreateControllerSpec.php
+++ b/spec/Controller/ClientCreateControllerSpec.php
@@ -25,6 +25,7 @@ use SimpleSAML\Module\oidc\Entity\ClientEntity;
 use SimpleSAML\Module\oidc\Factories\FormFactory;
 use SimpleSAML\Module\oidc\Factories\TemplateFactory;
 use SimpleSAML\Module\oidc\Form\ClientForm;
+use SimpleSAML\Module\oidc\Repositories\AllowedOriginRepository;
 use SimpleSAML\Module\oidc\Repositories\ClientRepository;
 use SimpleSAML\Module\oidc\Services\ConfigurationService;
 use SimpleSAML\Module\oidc\Services\SessionMessagesService;
@@ -40,6 +41,7 @@ class ClientCreateControllerSpec extends ObjectBehavior
     public function let(
         ConfigurationService $configurationService,
         ClientRepository $clientRepository,
+        AllowedOriginRepository $allowedOriginRepository,
         TemplateFactory $templateFactory,
         FormFactory $formFactory,
         SessionMessagesService $sessionMessagesService,
@@ -57,6 +59,7 @@ class ClientCreateControllerSpec extends ObjectBehavior
         $this->beConstructedWith(
             $configurationService,
             $clientRepository,
+            $allowedOriginRepository,
             $templateFactory,
             $formFactory,
             $sessionMessagesService
@@ -99,6 +102,7 @@ class ClientCreateControllerSpec extends ObjectBehavior
         FormFactory $formFactory,
         ClientForm $clientForm,
         ClientRepository $clientRepository,
+        AllowedOriginRepository $allowedOriginRepository,
         SessionMessagesService $sessionMessagesService
     ) {
         $formFactory->build(ClientForm::class)->shouldBeCalled()->willReturn($clientForm);
@@ -113,9 +117,13 @@ class ClientCreateControllerSpec extends ObjectBehavior
             'scopes' => ['openid'],
             'is_enabled' => true,
             'is_confidential' => false,
+            'allowed_origin' => []
         ]);
 
         $clientRepository->add(Argument::type(ClientEntity::class))->shouldBeCalled();
+
+        $allowedOriginRepository->set(Argument::type('string'), [])->shouldBeCalled();
+
         $sessionMessagesService->addMessage('{oidc:client:added}')->shouldBeCalled();
 
         $this->__invoke($request)->shouldBeAnInstanceOf(RedirectResponse::class);

--- a/spec/Controller/ClientShowControllerSpec.php
+++ b/spec/Controller/ClientShowControllerSpec.php
@@ -23,6 +23,7 @@ use SimpleSAML\Error\NotFound;
 use SimpleSAML\Module\oidc\Controller\ClientShowController;
 use SimpleSAML\Module\oidc\Entity\ClientEntity;
 use SimpleSAML\Module\oidc\Factories\TemplateFactory;
+use SimpleSAML\Module\oidc\Repositories\AllowedOriginRepository;
 use SimpleSAML\Module\oidc\Repositories\ClientRepository;
 use SimpleSAML\XHTML\Template;
 
@@ -35,6 +36,7 @@ class ClientShowControllerSpec extends ObjectBehavior
      */
     public function let(
         ClientRepository $clientRepository,
+        AllowedOriginRepository $allowedOriginRepository,
         TemplateFactory $templateFactory,
         ServerRequest $request,
         UriInterface $uri
@@ -45,7 +47,7 @@ class ClientShowControllerSpec extends ObjectBehavior
         $request->getUri()->willReturn($uri);
         $uri->getPath()->willReturn('/');
 
-        $this->beConstructedWith($clientRepository, $templateFactory);
+        $this->beConstructedWith($clientRepository, $allowedOriginRepository, $templateFactory);
     }
 
     /**
@@ -66,13 +68,19 @@ class ClientShowControllerSpec extends ObjectBehavior
         Template $template,
         TemplateFactory $templateFactory,
         ClientRepository $clientRepository,
+        AllowedOriginRepository $allowedOriginRepository,
         ClientEntity $clientEntity
     ) {
         $request->getQueryParams()->shouldBeCalled()->willReturn(['client_id' => 'clientid']);
+        $clientEntity->getIdentifier()->shouldBeCalled()->willReturn('clientid');
         $clientRepository->findById('clientid')->shouldBeCalled()->willReturn($clientEntity);
+        $allowedOriginRepository->get('clientid')->shouldBeCalled()->willReturn([]);
 
-        $templateFactory->render('oidc:clients/show.twig', ['client' => $clientEntity])
-            ->shouldBeCalled()->willReturn($template);
+        $templateFactory->render('oidc:clients/show.twig', [
+            'client' => $clientEntity,
+            'allowedOrigins' => []
+         ])->shouldBeCalled()
+         ->willReturn($template);
         $this->__invoke($request)->shouldBe($template);
     }
 

--- a/spec/Controller/OpenIdConnectUserInfoControllerSpec.php
+++ b/spec/Controller/OpenIdConnectUserInfoControllerSpec.php
@@ -15,6 +15,7 @@
 namespace spec\SimpleSAML\Module\oidc\Controller;
 
 use Laminas\Diactoros\Response\JsonResponse;
+use Laminas\Diactoros\Response;
 use Laminas\Diactoros\ServerRequest;
 use League\OAuth2\Server\ResourceServer;
 use PhpSpec\ObjectBehavior;
@@ -26,6 +27,7 @@ use SimpleSAML\Module\oidc\Entity\UserEntity;
 use SimpleSAML\Module\oidc\Repositories\AccessTokenRepository;
 use SimpleSAML\Module\oidc\Repositories\AllowedOriginRepository;
 use SimpleSAML\Module\oidc\Repositories\UserRepository;
+use SimpleSAML\Module\oidc\Server\Exceptions\OidcServerException;
 
 class OpenIdConnectUserInfoControllerSpec extends ObjectBehavior
 {
@@ -89,12 +91,48 @@ class OpenIdConnectUserInfoControllerSpec extends ObjectBehavior
         $this->__invoke($request)->shouldHavePayload(['email' => 'userid@localhost.localdomain']);
     }
 
+    public function it_handles_cors_request(
+        ServerRequest $request,
+        AllowedOriginRepository $allowedOriginRepository
+    ) {
+        $origin = 'https://example.org';
+        $request->getMethod()->shouldBeCalled()->willReturn('OPTIONS');
+        $request->getHeaderLine('Origin')->shouldBeCalled()->willReturn($origin);
+
+        $allowedOriginRepository->has($origin)->shouldBeCalled()->willReturn(true);
+
+        $this->__invoke($request)->shouldHaveHeaders([
+            ['name' => 'Access-Control-Allow-Origin', 'value' => $origin],
+            ['name' => 'Access-Control-Allow-Methods', 'value' => 'GET, POST, OPTIONS'],
+            ['name' => 'Access-Control-Allow-Headers', 'value' => 'Authorization'],
+            ['name' => 'Access-Control-Allow-Credentials', 'value' => 'true'],
+        ]);
+    }
+
+    public function it_throws_if_cors_origin_not_allowed(
+        ServerRequest $request,
+        AllowedOriginRepository $allowedOriginRepository
+    ) {
+        $origin = 'https://example.org';
+        $request->getMethod()->shouldBeCalled()->willReturn('OPTIONS');
+        $request->getHeaderLine('Origin')->shouldBeCalled()->willReturn($origin);
+
+        $allowedOriginRepository->has($origin)->shouldBeCalled()->willReturn(false);
+
+        $this->shouldThrow(OidcServerException::class)->during('__invoke', [$request]);
+    }
+
     public function getMatchers(): array
     {
         return [
             'havePayload' => function (JsonResponse $subject, $payload) {
                 return $payload === $subject->getPayload();
             },
+            'haveHeaders' => function (Response $response, $headers) {
+                return array_reduce($headers, function ($carry, $header) use ($response) {
+                    return $carry && $response->getHeaderLine($header['name']) === $header['value'];
+                }, true);
+            }
         ];
     }
 }

--- a/spec/Controller/OpenIdConnectUserInfoControllerSpec.php
+++ b/spec/Controller/OpenIdConnectUserInfoControllerSpec.php
@@ -24,6 +24,7 @@ use SimpleSAML\Module\oidc\Controller\OpenIdConnectUserInfoController;
 use SimpleSAML\Module\oidc\Entity\AccessTokenEntity;
 use SimpleSAML\Module\oidc\Entity\UserEntity;
 use SimpleSAML\Module\oidc\Repositories\AccessTokenRepository;
+use SimpleSAML\Module\oidc\Repositories\AllowedOriginRepository;
 use SimpleSAML\Module\oidc\Repositories\UserRepository;
 
 class OpenIdConnectUserInfoControllerSpec extends ObjectBehavior
@@ -35,9 +36,16 @@ class OpenIdConnectUserInfoControllerSpec extends ObjectBehavior
         ResourceServer $resourceServer,
         AccessTokenRepository $accessTokenRepository,
         UserRepository $userRepository,
+        AllowedOriginRepository $allowedOriginRepository,
         ClaimTranslatorExtractor $claimTranslatorExtractor
     ) {
-        $this->beConstructedWith($resourceServer, $accessTokenRepository, $userRepository, $claimTranslatorExtractor);
+        $this->beConstructedWith(
+            $resourceServer,
+            $accessTokenRepository,
+            $userRepository,
+            $allowedOriginRepository,
+            $claimTranslatorExtractor
+        );
     }
 
     /**

--- a/spec/Controller/OpenIdConnectUserInfoControllerSpec.php
+++ b/spec/Controller/OpenIdConnectUserInfoControllerSpec.php
@@ -61,6 +61,7 @@ class OpenIdConnectUserInfoControllerSpec extends ObjectBehavior
         UserEntity $userEntity,
         ClaimTranslatorExtractor $claimTranslatorExtractor
     ) {
+        $request->getMethod()->shouldBeCalled()->willReturn('GET');
         $resourceServer->validateAuthenticatedRequest($request)->shouldBeCalled()->willReturn($authorization);
         $authorization->getAttribute('oauth_access_token_id')->shouldBeCalled()->willReturn('tokenid');
         $authorization->getAttribute('oauth_scopes')->shouldBeCalled()->willReturn(['openid', 'email']);

--- a/templates/clients/_form.twig
+++ b/templates/clients/_form.twig
@@ -100,6 +100,7 @@
 
         $.fn.form.settings.rules.redirectUri = function(value) {
             return value.trim().split("\n").reduce(function(current, url) {
+                // Important if updating regex: also used in PHP validation in lib/Form/ClientForm.php
                 return current && null !== url.match(/^[^:]+:\/\/?[^\s\/$.?#].[^\s]*$/);
             }, true)
         };
@@ -109,7 +110,8 @@
 
             if (urls.length && urls[0] !== '') {
                 return urls.reduce(function(current, url) {
-                    return current && null !== url.match(/http(s?)\:\/\/[^\s\/$.?#]+\.[^\s\/$.?#]+(\.[^\s\/$.?#]+)*$/i);
+                    // Important if updating regex: also used in PHP validation in lib/Form/ClientForm.php
+                    return current && null !== url.match(/^http(s?):\/\/[^\s\/!$&'()+,;=.?#@*:]+\.[^\s\/!$&'()+,;=.?#@*]+\.?(\.[^\s\/!$&'()+,;=?#@*:]+)*(:\d{1,5})?$/i);
                 }, true)
             }
 

--- a/templates/clients/_form.twig
+++ b/templates/clients/_form.twig
@@ -41,6 +41,7 @@
                 <input name="is_confidential" id="frm-is_confidential" {% if form['is_confidential'].filled %}checked=""{% endif %} type="checkbox">
 
                 <label for="frm-is_confidential">{% trans '{oidc:client:is_confidential}' %}</label>
+                <small class="helper">{% trans '{oidc:client:is_confidential_help}' %}</small>
             </div>
         </div>
 
@@ -88,6 +89,15 @@
 {% block postload %}
     {{ parent() }}
     <script>
+        $(document).ready(function () {
+            toggleAllowedOrigins();
+             $('#frm-is_confidential').change(toggleAllowedOrigins);
+        });
+
+        function toggleAllowedOrigins() {
+            $('#frm-allowed_origin').prop('disabled', $('#frm-is_confidential').prop('checked'));
+        }
+
         $.fn.form.settings.rules.redirectUri = function(value) {
             return value.trim().split("\n").reduce(function(current, url) {
                 return current && null !== url.match(/^[^:]+:\/\/?[^\s\/$.?#].[^\s]*$/);
@@ -99,7 +109,7 @@
 
             if (urls.length && urls[0] !== '') {
                 return urls.reduce(function(current, url) {
-                    return current && null !== url.match(/http(s?)\:\/\/[^\s\/$.?#]+\.[^\s\/$.?#]+(\.[^\s\/$.?#]+)?$/i);
+                    return current && null !== url.match(/http(s?)\:\/\/[^\s\/$.?#]+\.[^\s\/$.?#]+(\.[^\s\/$.?#]+)*$/i);
                 }, true)
             }
 
@@ -156,6 +166,8 @@
                         ]
                     }
                 }
-            })
+            });
+
+
     </script>
 {% endblock %}

--- a/templates/clients/_form.twig
+++ b/templates/clients/_form.twig
@@ -64,6 +64,13 @@
             {{ form['scopes'].control | raw }}
         </div>
 
+        <div class="field">
+            <label for="frm-allowed_origin">{% trans '{oidc:client:allowed_origin}' %}</label>
+
+            {{ form['allowed_origin'].control | raw }}
+            <small class="helper">{% trans '{oidc:client:allowed_origin_help}' %}</small>
+        </div>
+
         <div class="ui divider"></div>
 
         <div class="ui buttons">
@@ -87,11 +94,22 @@
             }, true)
         };
 
-        $('.ui.form')
-            .checkbox();
+        $.fn.form.settings.rules.allowedOrigin = function(value) {
+            var urls = value.trim().split("\n");
 
-        $('.ui.form')
-            .form({
+            if (urls.length && urls[0] !== '') {
+                return urls.reduce(function(current, url) {
+                    return current && null !== url.match(/http(s?)\:\/\/[^\s\/$.?#]+\.[^\s\/$.?#]+(\.[^\s\/$.?#]+)?$/i);
+                }, true)
+            }
+
+            return true;
+        };
+
+        var formEl = $('.ui.form');
+        formEl.checkbox();
+
+        formEl.form({
                 fields: {
                     name: {
                         identifier: 'name',
@@ -122,10 +140,18 @@
                     scopes: {
                         identifier: 'scopes[]',
                         rules: [
-
                             {
                                 type: 'minCount[1]',
                                 prompt: '{% trans "{oidc:client:scopes_not_empty}" %}'
+                            }
+                        ]
+                    },
+                    allowed_origin: {
+                        identifier: 'allowed_origin',
+                        rules: [
+                            {
+                                type: 'allowedOrigin',
+                                prompt: '{% trans "{oidc:client:allowed_origin_not_valid}" %}'
                             }
                         ]
                     }

--- a/templates/clients/show.twig
+++ b/templates/clients/show.twig
@@ -72,6 +72,16 @@
                 </ul>
             </td>
         </tr>
+        <tr>
+            <td class="collapsing">{% trans '{oidc:client:allowed_origin}' %}</td>
+            <td>
+                <ul class="list">
+                    {% for allowedOrigin in allowedOrigins %}
+                        <li>{{ allowedOrigin }}</li>
+                    {% endfor %}
+                </ul>
+            </td>
+        </tr>
         </tbody>
         <tfoot>
         <tr class="full-width">

--- a/tests/Repositories/AllowedOriginRepositoryTest.php
+++ b/tests/Repositories/AllowedOriginRepositoryTest.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace SimpleSAML\Test\Module\oidc\Repositories;
+
+use SimpleSAML\Configuration;
+use SimpleSAML\Module\oidc\Repositories\AllowedOriginRepository;
+use PHPUnit\Framework\TestCase;
+use SimpleSAML\Module\oidc\Repositories\ClientRepository;
+use SimpleSAML\Module\oidc\Services\ConfigurationService;
+use SimpleSAML\Module\oidc\Services\DatabaseMigration;
+
+/**
+ * @covers \SimpleSAML\Module\oidc\Repositories\AllowedOriginRepository
+ */
+class AllowedOriginRepositoryTest extends TestCase
+{
+    public const CLIENT_ID = 'some_client_id';
+
+    public const ORIGINS = [
+        'https://example.org',
+        'https://sample.com',
+    ];
+
+    /**
+     * @var AllowedOriginRepository
+     */
+    private static $repository;
+
+    /**
+     * @var ConfigurationService
+     */
+    private static $configurationService;
+
+    public static function setUpBeforeClass(): void
+    {
+        $config = [
+            'database.dsn' => 'sqlite::memory:',
+            'database.username' => null,
+            'database.password' => null,
+            'database.prefix' => 'phpunit_',
+            'database.persistent' => true,
+            'database.slaves' => [],
+        ];
+
+        Configuration::loadFromArray($config, '', 'simplesaml');
+        (new DatabaseMigration())->migrate();
+
+        self::$configurationService = new ConfigurationService();
+
+        $client = ClientRepositoryTest::getClient(self::CLIENT_ID);
+        (new ClientRepository(self::$configurationService))->add($client);
+
+        self::$repository = new AllowedOriginRepository(self::$configurationService);
+    }
+
+    public function tearDown(): void
+    {
+        self::$repository->delete(self::CLIENT_ID);
+    }
+
+    public function testGetTableName(): void
+    {
+        $this->assertSame('phpunit_oidc_allowed_origin', self::$repository->getTableName());
+    }
+
+    public function testSetGetHasDelete(): void
+    {
+        self::$repository->set(self::CLIENT_ID, []);
+        $this->assertSame([], self::$repository->get(self::CLIENT_ID));
+
+        self::$repository->set(self::CLIENT_ID, self::ORIGINS);
+        $this->assertSame(self::ORIGINS, self::$repository->get(self::CLIENT_ID));
+        $this->assertTrue(self::$repository->has(self::ORIGINS[0]));
+        $this->assertTrue(self::$repository->has(self::ORIGINS[1]));
+        $this->assertFalse(self::$repository->has('https://invalid.org'));
+
+        self::$repository->delete(self::CLIENT_ID);
+        $this->assertFalse(self::$repository->has(self::ORIGINS[0]));
+        $this->assertFalse(self::$repository->has(self::ORIGINS[1]));
+    }
+}


### PR DESCRIPTION
Add new DB table and repository to store allowed origins for particular clients.

For HTTP preflight requests (HTTP OPTIONS method) to 'userinfo' endpoint, set appropriate CORS headers if particular origin is allowed.

Fixes #103 