### PR TITLE
Bump required PHP version to 7.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         }
     ],
     "require": {
-        "php": ">=7.2.0",
+        "php": ">=7.4",
         "ext-json": "*",
         "ext-openssl": "*",
         "ext-pdo": "*",


### PR DESCRIPTION
Since we already rely on package(s) which require PHP 7.4, we might as well designate this as our own requirement in composer.json.